### PR TITLE
Add GoogleFontsPicker and delay font population until viewport intersects with picker

### DIFF
--- a/src/_includes/components/GoogleFontsPicker/index.jsx
+++ b/src/_includes/components/GoogleFontsPicker/index.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+
+const GoogleFontsPicker = ({ defaultValue, fonts: allFonts, onChange }) => {
+  const [fonts, setFonts] = useState([defaultValue]);
+  const pickerRef = useRef(null);
+
+  /* Set fonts from static props (async 11ty data) on intersection, for several reasons:
+    1. Scalability: Don't want to fetch Google Fonts on mount because that would require using serverless functions. Without a cache, assuming decent traffic, this would quickly blow the Netlify limit.
+    2. SEO: Don't want the initially server-side rendered HTML to return ~1k font family names, or this will start matching really absurd and irrelevant search queries (already seeing this in Google Search Console).
+    3. Performance: This sends less HTML over the wire initially and on mount. */
+  useEffect(() => {
+    if (!pickerRef.current) return;
+    const intersectionObserver = new IntersectionObserver(
+      (entries, self) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setFonts(allFonts);
+            self.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: `400px 0px 400px 0px` }
+    );
+    intersectionObserver.observe(pickerRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <select ref={pickerRef} defaultValue={defaultValue} onChange={onChange}>
+      {fonts.map((fontFamily) => (
+        <option key={fontFamily} value={fontFamily}>
+          {fontFamily}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default GoogleFontsPicker;

--- a/src/_includes/components/Preview/constants.js
+++ b/src/_includes/components/Preview/constants.js
@@ -1,0 +1,1 @@
+export const defaultFonts = ['Inter'];

--- a/src/_includes/components/Preview/index.jsx
+++ b/src/_includes/components/Preview/index.jsx
@@ -3,6 +3,7 @@ import Input from '../Input';
 import RangeInput from '../RangeInput';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
+import GoogleFontsPicker from '../GoogleFontsPicker';
 
 // No need to use a Head lib
 const getFontLinkTag = (id) => {
@@ -26,19 +27,12 @@ const defaultFonts = ['Inter'];
 
 const Preview = (props) => {
   const [previewText, setPreviewText] = useState('Almost before we knew it, we had left the ground');
-  const [fonts, setFonts] = useState(defaultFonts);
   const [previewFont, setPreviewFont] = useState(defaultFonts[0]);
   const [screenWidth, setScreenWidth] = useState(props.baseSizes.max.screenWidth);
 
   useEffect(() => {
     // Since Slinkity uses SSR, this must be done on mount
     setScreenWidth(window.innerWidth);
-    /* Set fonts from static props (async 11ty data) on mount, for several reasons:
-    1. Don't want to fetch Google Fonts on mount because that would require using serverless functions. Without a cache, assuming decent traffic, this would quickly blow the Netlify limit.
-    2. Don't want the initially server-side rendered HTML to return ~1k font family names, or this will start matching really absurd and irrelevant search queries (already seeing this in Google Search Console).
-    3. This sends less HTML over the wire initially.
-    */
-    setFonts(props.fonts);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -64,13 +58,11 @@ const Preview = (props) => {
         />
         <label className="label">
           <span className="label-title">Font family</span>
-          <select defaultValue={previewFont} onChange={(e) => onFontSelected(e.target.value)}>
-            {fonts.map((fontFamily) => (
-              <option key={fontFamily} value={fontFamily}>
-                {fontFamily}
-              </option>
-            ))}
-          </select>
+          <GoogleFontsPicker
+            fonts={props.fonts}
+            defaultValue={previewFont}
+            onChange={(e) => onFontSelected(e.target.value)}
+          />
         </label>
         <label className="label">
           <span className="label-title">Preview text</span>

--- a/src/_includes/components/Preview/index.jsx
+++ b/src/_includes/components/Preview/index.jsx
@@ -4,31 +4,13 @@ import RangeInput from '../RangeInput';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
 import GoogleFontsPicker from '../GoogleFontsPicker';
+import { getFontLinkTag, onLinkLoaded } from './utils';
+import { defaultFonts } from './constants';
 
-// No need to use a Head lib
-const getFontLinkTag = (id) => {
-  const existingLink = document.getElementById(id);
-  if (existingLink) {
-    document.head.removeChild(existingLink);
-  }
-  const link = document.createElement('link');
-  link.removeEventListener('load', onLinkLoaded);
-  link.id = id;
-  link.rel = 'stylesheet';
-  return link;
-};
-
-const onLinkLoaded = (fontFamily, previewText, setFont) => async () => {
-  await document.fonts.load(`1em ${fontFamily}`, previewText);
-  setFont(fontFamily);
-};
-
-const defaultFonts = ['Inter'];
-
-const Preview = (props) => {
+const Preview = ({ baseSizes, fonts, typeScale }) => {
   const [previewText, setPreviewText] = useState('Almost before we knew it, we had left the ground');
   const [previewFont, setPreviewFont] = useState(defaultFonts[0]);
-  const [screenWidth, setScreenWidth] = useState(props.baseSizes.max.screenWidth);
+  const [screenWidth, setScreenWidth] = useState(baseSizes.max.screenWidth);
 
   useEffect(() => {
     // Since Slinkity uses SSR, this must be done on mount
@@ -59,7 +41,7 @@ const Preview = (props) => {
         <label className="label">
           <span className="label-title">Font family</span>
           <GoogleFontsPicker
-            fonts={props.fonts}
+            fonts={fonts}
             defaultValue={previewFont}
             onChange={(e) => onFontSelected(e.target.value)}
           />
@@ -89,7 +71,7 @@ const Preview = (props) => {
             </tr>
           </thead>
           <tbody>
-            {Object.entries(props.typeScale).map(([step, { min, max, getFontSizeAtScreenWidth }]) => {
+            {Object.entries(typeScale).map(([step, { min, max, getFontSizeAtScreenWidth }]) => {
               const fontSize = getFontSizeAtScreenWidth(screenWidth);
               return (
                 <tr key={step}>

--- a/src/_includes/components/Preview/utils.js
+++ b/src/_includes/components/Preview/utils.js
@@ -1,0 +1,17 @@
+// No need to use a Head lib
+export const getFontLinkTag = (id) => {
+  const existingLink = document.getElementById(id);
+  if (existingLink) {
+    document.head.removeChild(existingLink);
+  }
+  const link = document.createElement('link');
+  link.removeEventListener('load', onLinkLoaded);
+  link.id = id;
+  link.rel = 'stylesheet';
+  return link;
+};
+
+export const onLinkLoaded = (fontFamily, previewText, setFont) => async () => {
+  await document.fonts.load(`1em ${fontFamily}`, previewText);
+  setFont(fontFamily);
+};


### PR DESCRIPTION
Follow-up to #3. Resolves the excessive DOM size issues reported by Lighthouse and improves mobile performance:

![image](https://user-images.githubusercontent.com/19352442/147878083-7e2ec638-4315-40f6-8e95-61299fc18fad.png)

Summary:

- New GoogleFontsPicker component that delays initialization of fonts until it intersects with the viewport, +/- an arbitrary 400px.
- Minor code organization cleanup.