### PR TITLE
Standardize input/select styling

### DIFF
--- a/styles/partials/global/_reset.scss
+++ b/styles/partials/global/_reset.scss
@@ -27,6 +27,14 @@ a {
   font-weight: inherit;
 }
 
+select {
+  appearance: none;
+  background-color: var(--color-surface-light);
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24"><path d="M2 4l10 12l10-12" stroke-width="4" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" fill="none"/></svg>');
+  background-repeat: no-repeat;
+  background-position: calc(100% - var(--input-padding)) center;
+}
+
 /* stylelint-disable-next-line no-descending-specificity */
 button,
 label,
@@ -40,7 +48,10 @@ option {
 input,
 select,
 textarea {
-  padding: 8px;
+  --input-padding: 8px;
+  padding: var(--input-padding);
+  border-radius: 0;
+  border: solid 1px var(--color-border);
 }
 
 select,


### PR DESCRIPTION
For consistency across:

- Firefox (Windows, Mac)—background color was picking up the OS theme.
- Safari (Mac)—without `appearance: none`, these were appearing as default OS-themed inputs that don't respect height properties (https://stackoverflow.com/a/17469167/5323344).

Chrome was the only one that behaved itself, but now they should all look the same.

Examples:

Firefox (before)

![image](https://user-images.githubusercontent.com/19352442/148143453-528958bc-7881-49de-ad66-e8bdc7af156b.png)

Firefox (after)

![image](https://user-images.githubusercontent.com/19352442/148143428-05c32e6b-db48-433e-8a07-7a7f2d4d4943.png)
