### PR TITLE
Make performance/code organization adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "clsx": "^1.1.1",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/src/_includes/components/FluidTypeScaleGenerator.jsx
+++ b/src/_includes/components/FluidTypeScaleGenerator.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from 'react';
+import { useReducer } from 'react';
 import Form from './Form';
 import Output from './Output';
 import { Action, initialState } from './constants';
@@ -40,60 +40,46 @@ const reducer = (state, action) => {
 const FluidTypeScaleGenerator = (props) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  // Memoize because some state variables shouldn't trigger recomputing the type scale
+  /** Appends the correct unit to a unitless value. */
+  const withUnit = (unitlessValue) => (state.shouldUseRems ? `${unitlessValue}rem` : `${unitlessValue}px`);
+
+  /** Rounds the given value to a fixed number of decimal places, according to the user's specified value. */
+  const round = (val) => Number(val.toFixed(state.roundingDecimalPlaces));
+
+  /** If we're using rems, converts the pixel arg to rems. Else, keeps it in pixels. */
+  const convertToDesiredUnit = (px) => (state.shouldUseRems ? px / 16 : px);
+
+  // Get the index of the base modular step to compute exponents relative to the base index (up/down)
+  const baseModularStepIndex = state.modularSteps.indexOf(state.baseModularStep);
+
   /** @type {import('./typedefs').TypeScale} */
-  const typeScale = useMemo(() => {
-    /** Appends the correct unit to a unitless value. */
-    const withUnit = (unitlessValue) => (state.shouldUseRems ? `${unitlessValue}rem` : `${unitlessValue}px`);
+  const typeScale = state.modularSteps.reduce((steps, step, i) => {
+    const min = {
+      fontSize: state.min.fontSize * Math.pow(state.min.modularRatio, i - baseModularStepIndex),
+      breakpoint: state.min.screenWidth,
+    };
+    const max = {
+      fontSize: state.max.fontSize * Math.pow(state.max.modularRatio, i - baseModularStepIndex),
+      breakpoint: state.max.screenWidth,
+    };
+    const slope = (max.fontSize - min.fontSize) / (max.breakpoint - min.breakpoint);
+    const slopeVw = `${round(slope * 100)}vw`;
+    const intercept = min.fontSize - slope * min.breakpoint;
 
-    /** Rounds the given value to a fixed number of decimal places, according to the user's specified value. */
-    const round = (val) => Number(val.toFixed(state.roundingDecimalPlaces));
-
-    /** If we're using rems, converts the pixel arg to rems. Else, keeps it in pixels. */
-    const convertToDesiredUnit = (px) => (state.shouldUseRems ? px / 16 : px);
-
-    // Get the index of the base modular step to compute exponents relative to the base index (up/down)
-    const baseModularStepIndex = state.modularSteps.indexOf(state.baseModularStep);
-
-    return state.modularSteps.reduce((steps, step, i) => {
-      const min = {
-        fontSize: state.min.fontSize * Math.pow(state.min.modularRatio, i - baseModularStepIndex),
-        breakpoint: state.min.screenWidth,
-      };
-      const max = {
-        fontSize: state.max.fontSize * Math.pow(state.max.modularRatio, i - baseModularStepIndex),
-        breakpoint: state.max.screenWidth,
-      };
-      const slope = (max.fontSize - min.fontSize) / (max.breakpoint - min.breakpoint);
-      const slopeVw = `${round(slope * 100)}vw`;
-      const intercept = min.fontSize - slope * min.breakpoint;
-
-      steps.set(step, {
-        min: withUnit(round(convertToDesiredUnit(min.fontSize))),
-        max: withUnit(round(convertToDesiredUnit(max.fontSize))),
-        preferred: `${slopeVw} + ${withUnit(round(convertToDesiredUnit(intercept)))}`,
-        getFontSizeAtScreenWidth: (width) => {
-          let preferredFontSize = width * slope + intercept;
-          preferredFontSize = Math.min(max.fontSize, preferredFontSize);
-          preferredFontSize = Math.max(min.fontSize, preferredFontSize);
-          return withUnit(round(convertToDesiredUnit(preferredFontSize)));
-        },
-      });
-      return steps;
-      // NOTE: Using a Map instead of an object to preserve key insertion order.
-    }, new Map());
-  }, [
-    state.baseModularStep,
-    state.max.fontSize,
-    state.max.modularRatio,
-    state.max.screenWidth,
-    state.min.fontSize,
-    state.min.modularRatio,
-    state.min.screenWidth,
-    state.modularSteps,
-    state.roundingDecimalPlaces,
-    state.shouldUseRems,
-  ]);
+    steps.set(step, {
+      min: withUnit(round(convertToDesiredUnit(min.fontSize))),
+      max: withUnit(round(convertToDesiredUnit(max.fontSize))),
+      preferred: `${slopeVw} + ${withUnit(round(convertToDesiredUnit(intercept)))}`,
+      getFontSizeAtScreenWidth: (width) => {
+        let preferredFontSize = width * slope + intercept;
+        preferredFontSize = Math.min(max.fontSize, preferredFontSize);
+        preferredFontSize = Math.max(min.fontSize, preferredFontSize);
+        return withUnit(round(convertToDesiredUnit(preferredFontSize)));
+      },
+    });
+    return steps;
+    // NOTE: Using a Map instead of an object to preserve key insertion order.
+  }, new Map());
 
   return (
     <div className={styles['type-scale-generator']}>

--- a/src/_includes/components/FluidTypeScaleGenerator.jsx
+++ b/src/_includes/components/FluidTypeScaleGenerator.jsx
@@ -1,28 +1,9 @@
 import { useMemo, useReducer } from 'react';
 import Form from './Form';
 import Output from './Output';
-import { Action, modularRatios } from './constants';
+import { Action, initialState } from './constants';
 import Preview from './Preview';
 import styles from './styles.module.scss';
-
-/** @type {import('./typedefs').AppState} */
-export const initialState = {
-  min: {
-    fontSize: 16,
-    screenWidth: 400,
-    modularRatio: modularRatios.majorThird.ratio,
-  },
-  max: {
-    fontSize: 19,
-    screenWidth: 1280,
-    modularRatio: modularRatios.perfectFourth.ratio,
-  },
-  modularSteps: ['sm', 'base', 'md', 'lg', 'xl', 'xxl', 'xxxl'],
-  baseModularStep: 'base',
-  namingConvention: 'font-size',
-  shouldUseRems: true,
-  roundingDecimalPlaces: 2,
-};
 
 /**
  * @param {import('./typedefs').AppState} state - the previous app state
@@ -123,7 +104,7 @@ const FluidTypeScaleGenerator = (props) => {
         <Form {...state} dispatch={dispatch} />
         <Output namingConvention={state.namingConvention} typeScale={typeScale} />
       </div>
-      <Preview baseSizes={{ min: { ...state.min }, max: { ...state.max } }} typeScale={typeScale} fonts={props.fonts} />
+      <Preview typeScale={typeScale} fonts={props.fonts} />
     </div>
   );
 };

--- a/src/_includes/components/Form/GroupMaximum/index.jsx
+++ b/src/_includes/components/Form/GroupMaximum/index.jsx
@@ -1,0 +1,64 @@
+import { Action } from '../../constants';
+import Input from '../../Input';
+import TypeScalePicker from '../../TypeScalePicker';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'max'> & { dispatch: import("../../typedefs").AppDispatcher; minScreenWidth: number }} props
+ */
+const GroupMaximum = (props) => {
+  const { max, dispatch, minScreenWidth } = props;
+
+  return (
+    <fieldset className="label">
+      <legend>
+        <span className="label-title">Maximum (Desktop)</span>
+        <span className="label-description">
+          Define the maximum font size and viewport width for your type scale&apos;s baseline step. The max font size
+          for all other steps is this baseline font size scaled up/down by your chosen type scale ratio.
+        </span>
+      </legend>
+      <div className="label-group">
+        <label>
+          Base font size (pixels)
+          <Input
+            type="number"
+            required={true}
+            min={0}
+            defaultValue={max.fontSize}
+            onChange={(e) =>
+              dispatch({
+                type: Action.SET_MAX,
+                payload: {
+                  fontSize: Number(e.target.value),
+                },
+              })
+            }
+          />
+        </label>
+        <label>
+          Screen width (pixels)
+          <Input
+            type="number"
+            required={true}
+            min={minScreenWidth + 1}
+            defaultValue={max.screenWidth}
+            onChange={(e) =>
+              dispatch({
+                type: Action.SET_MAX,
+                payload: {
+                  screenWidth: Number(e.target.value),
+                },
+              })
+            }
+          />
+        </label>
+        <TypeScalePicker
+          ratio={max.modularRatio}
+          onChange={(e) => dispatch({ type: Action.SET_MAX, payload: { modularRatio: Number(e.target.value) } })}
+        />
+      </div>
+    </fieldset>
+  );
+};
+
+export default GroupMaximum;

--- a/src/_includes/components/Form/GroupMinimum/index.jsx
+++ b/src/_includes/components/Form/GroupMinimum/index.jsx
@@ -1,0 +1,64 @@
+import { Action } from '../../constants';
+import Input from '../../Input';
+import TypeScalePicker from '../../TypeScalePicker';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'min'> & { dispatch: import("../../typedefs").AppDispatcher; maxScreenWidth: number }} props
+ */
+const GroupMinimum = (props) => {
+  const { min, dispatch, maxScreenWidth } = props;
+  return (
+    <fieldset className="label">
+      <legend>
+        <span className="label-title">Minimum (Mobile)</span>
+        <span className="label-description">
+          Define the minimum font size and viewport width for your type scale&apos;s baseline step. The minimum font
+          size for all other steps is this baseline font size scaled up/down by your chosen type scale ratio.
+        </span>
+      </legend>
+      <div className="label-group">
+        <label>
+          Base font size (pixels)
+          <Input
+            type="number"
+            required={true}
+            min={0}
+            defaultValue={min.fontSize}
+            onChange={(e) =>
+              dispatch({
+                type: Action.SET_MIN,
+                payload: {
+                  fontSize: Number(e.target.value),
+                },
+              })
+            }
+          />
+        </label>
+        <label>
+          Screen width (pixels)
+          <Input
+            type="number"
+            required={true}
+            min={0}
+            max={maxScreenWidth - 1}
+            defaultValue={min.screenWidth}
+            onChange={(e) =>
+              dispatch({
+                type: Action.SET_MIN,
+                payload: {
+                  screenWidth: Number(e.target.value),
+                },
+              })
+            }
+          />
+        </label>
+        <TypeScalePicker
+          ratio={min.modularRatio}
+          onChange={(e) => dispatch({ type: Action.SET_MIN, payload: { modularRatio: Number(e.target.value) } })}
+        />
+      </div>
+    </fieldset>
+  );
+};
+
+export default GroupMinimum;

--- a/src/_includes/components/Form/GroupModularSteps/index.jsx
+++ b/src/_includes/components/Form/GroupModularSteps/index.jsx
@@ -1,0 +1,34 @@
+import { Action, Delay } from '../../constants';
+import Input from '../../Input';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'modularSteps'> & { dispatch: import("../../typedefs").AppDispatcher } } props
+ */
+const GroupModularSteps = (props) => {
+  const { modularSteps, dispatch } = props;
+  return (
+    <label className="label">
+      <span className="label-title">Type scale steps</span>
+      <span className="label-description">
+        A comma-separated list of names for each step in your type scale, in ascending order of size. Use any convention
+        you want.
+      </span>
+      <Input
+        type="text"
+        required
+        spellCheck="false"
+        pattern="^[a-zA-Z0-9-](?:(,\s*)?[a-zA-Z0-9-])*$"
+        defaultValue={modularSteps.join(',')}
+        delay={Delay.MEDIUM}
+        onChange={(e) =>
+          dispatch({
+            type: Action.SET_MODULAR_STEPS,
+            payload: e.target.value.split(',').map((step) => step.trim()),
+          })
+        }
+      />
+    </label>
+  );
+};
+
+export default GroupModularSteps;

--- a/src/_includes/components/Form/GroupNamingConvention/index.jsx
+++ b/src/_includes/components/Form/GroupNamingConvention/index.jsx
@@ -14,6 +14,7 @@ const GroupNamingConvention = (props) => {
         type="text"
         required={true}
         defaultValue={namingConvention}
+        delay={0}
         onChange={(e) =>
           dispatch({
             type: Action.SET_NAMING_CONVENTION,

--- a/src/_includes/components/Form/GroupNamingConvention/index.jsx
+++ b/src/_includes/components/Form/GroupNamingConvention/index.jsx
@@ -1,0 +1,28 @@
+import { Action } from '../../constants';
+import Input from '../../Input';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'namingConvention'> & { dispatch: import("../../typedefs").AppDispatcher } } props
+ */
+const GroupNamingConvention = (props) => {
+  const { namingConvention, dispatch } = props;
+  return (
+    <label className="label">
+      <span className="label-title">Variable naming convention</span>
+      <span className="label-description">Prefixed to each modular step to create unique variable names.</span>
+      <Input
+        type="text"
+        required={true}
+        defaultValue={namingConvention}
+        onChange={(e) =>
+          dispatch({
+            type: Action.SET_NAMING_CONVENTION,
+            payload: e.target.value,
+          })
+        }
+      />
+    </label>
+  );
+};
+
+export default GroupNamingConvention;

--- a/src/_includes/components/Form/GroupRounding/index.jsx
+++ b/src/_includes/components/Form/GroupRounding/index.jsx
@@ -1,0 +1,29 @@
+import { Action } from '../../constants';
+import Input from '../../Input';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'roundingDecimalPlaces'> & { dispatch: import("../../typedefs").AppDispatcher } } props
+ */
+const GroupRounding = (props) => {
+  const { roundingDecimalPlaces, dispatch } = props;
+  return (
+    <label className="label">
+      <span className="label-title">Rounding</span>
+      <span className="label-description">Control how many decimal places are shown in the output.</span>
+      <Input
+        type="number"
+        step={1}
+        min={0}
+        required={true}
+        defaultValue={roundingDecimalPlaces}
+        onChange={(e) =>
+          dispatch({
+            type: Action.SET_ROUNDING_DECIMAL_PLACES,
+            payload: Number(e.target.value),
+          })
+        }
+      />
+    </label>
+  );
+};
+export default GroupRounding;

--- a/src/_includes/components/Form/GroupUseRems/index.jsx
+++ b/src/_includes/components/Form/GroupUseRems/index.jsx
@@ -1,0 +1,24 @@
+import Checkbox from '../../Checkbox';
+import { Action } from '../../constants';
+
+/**
+ * @param {Pick<import("../../typedefs").AppState, 'shouldUseRems'> & { dispatch: import("../../typedefs").AppDispatcher } } props
+ */
+const GroupUseRems = (props) => {
+  const { shouldUseRems, dispatch } = props;
+  return (
+    <Checkbox
+      checked={shouldUseRems}
+      onChange={(e) =>
+        dispatch({
+          type: Action.SET_SHOULD_USE_REMS,
+          payload: e.target.checked,
+        })
+      }
+    >
+      Show output in rems
+    </Checkbox>
+  );
+};
+
+export default GroupUseRems;

--- a/src/_includes/components/Form/index.jsx
+++ b/src/_includes/components/Form/index.jsx
@@ -1,5 +1,5 @@
 import Checkbox from '../Checkbox';
-import { Action } from '../constants';
+import { Action, Delay } from '../constants';
 import Input from '../Input';
 import TypeScalePicker from '../TypeScalePicker';
 import styles from './styles.module.scss';
@@ -124,6 +124,7 @@ const Form = (props) => {
           spellCheck="false"
           pattern="^[a-zA-Z0-9-](?:(,\s*)?[a-zA-Z0-9-])*$"
           defaultValue={modularSteps.join(',')}
+          delay={Delay.MEDIUM}
           onChange={(e) =>
             dispatch({
               type: Action.SET_MODULAR_STEPS,

--- a/src/_includes/components/Form/index.jsx
+++ b/src/_includes/components/Form/index.jsx
@@ -1,11 +1,14 @@
-import Checkbox from '../Checkbox';
-import { Action, Delay } from '../constants';
-import Input from '../Input';
-import TypeScalePicker from '../TypeScalePicker';
+import GroupBaseModularStep from '../GroupBaseModularStep';
+import GroupMaximum from './GroupMaximum';
+import GroupMinimum from './GroupMinimum';
+import GroupModularSteps from './GroupModularSteps';
+import GroupNamingConvention from './GroupNamingConvention';
+import GroupRounding from './GroupRounding';
+import GroupUseRems from './GroupUseRems';
 import styles from './styles.module.scss';
 
 /**
- * @param {import('../typedefs').AppState & { dispatch: React.Dispatch<AppAction> }} props
+ * @param {import('../typedefs').AppState & { dispatch: import("../../typedefs").AppDispatcher }} props
  */
 const Form = (props) => {
   const { min, max, shouldUseRems, modularSteps, baseModularStep, namingConvention, roundingDecimalPlaces, dispatch } =
@@ -13,187 +16,13 @@ const Form = (props) => {
 
   return (
     <form className={styles.form}>
-      <fieldset className="label">
-        <legend>
-          <span className="label-title">Minimum (Mobile)</span>
-          <span className="label-description">
-            Define the minimum font size and viewport width for your type scale&apos;s baseline step. The minimum font
-            size for all other steps is this baseline font size scaled up/down by your chosen type scale ratio.
-          </span>
-        </legend>
-        <div className="label-group">
-          <label>
-            Base font size (pixels)
-            <Input
-              type="number"
-              required={true}
-              min={0}
-              defaultValue={min.fontSize}
-              onChange={(e) =>
-                dispatch({
-                  type: Action.SET_MIN,
-                  payload: {
-                    fontSize: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </label>
-          <label>
-            Screen width (pixels)
-            <Input
-              type="number"
-              required={true}
-              min={0}
-              max={max.screenWidth - 1}
-              defaultValue={min.screenWidth}
-              onChange={(e) =>
-                dispatch({
-                  type: Action.SET_MIN,
-                  payload: {
-                    screenWidth: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </label>
-          <TypeScalePicker
-            ratio={min.modularRatio}
-            onChange={(e) => dispatch({ type: Action.SET_MIN, payload: { modularRatio: Number(e.target.value) } })}
-          />
-        </div>
-      </fieldset>
-      <fieldset className="label">
-        <legend>
-          <span className="label-title">Maximum (Desktop)</span>
-          <span className="label-description">
-            Define the maximum font size and viewport width for your type scale&apos;s baseline step. The max font size
-            for all other steps is this baseline font size scaled up/down by your chosen type scale ratio.
-          </span>
-        </legend>
-        <div className="label-group">
-          <label>
-            Base font size (pixels)
-            <Input
-              type="number"
-              required={true}
-              min={0}
-              defaultValue={max.fontSize}
-              onChange={(e) =>
-                dispatch({
-                  type: Action.SET_MAX,
-                  payload: {
-                    fontSize: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </label>
-          <label>
-            Screen width (pixels)
-            <Input
-              type="number"
-              required={true}
-              min={min.screenWidth + 1}
-              defaultValue={max.screenWidth}
-              onChange={(e) =>
-                dispatch({
-                  type: Action.SET_MAX,
-                  payload: {
-                    screenWidth: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </label>
-          <TypeScalePicker
-            ratio={max.modularRatio}
-            onChange={(e) => dispatch({ type: Action.SET_MAX, payload: { modularRatio: Number(e.target.value) } })}
-          />
-        </div>
-      </fieldset>
-      <label className="label">
-        <span className="label-title">Type scale steps</span>
-        <span className="label-description">
-          A comma-separated list of names for each step in your type scale, in ascending order of size. Use any
-          convention you want.
-        </span>
-        <Input
-          type="text"
-          required
-          spellCheck="false"
-          pattern="^[a-zA-Z0-9-](?:(,\s*)?[a-zA-Z0-9-])*$"
-          defaultValue={modularSteps.join(',')}
-          delay={Delay.MEDIUM}
-          onChange={(e) =>
-            dispatch({
-              type: Action.SET_MODULAR_STEPS,
-              payload: e.target.value.split(',').map((step) => step.trim()),
-            })
-          }
-        />
-      </label>
-      <label className="label">
-        <span className="label-title">Baseline modular step</span>
-        <span className="label-description">
-          Identify the name of the baseline font size step in your type scale. This must appear in the list entered
-          above.
-        </span>
-        <Input
-          type="text"
-          required={true}
-          defaultValue={baseModularStep}
-          onChange={(e) =>
-            dispatch({
-              type: Action.SET_BASE_MODULAR_STEP,
-              payload: e.target.value,
-            })
-          }
-        />
-      </label>
-      <label className="label">
-        <span className="label-title">Variable naming convention</span>
-        <span className="label-description">Prefixed to each modular step to create unique variable names.</span>
-        <Input
-          type="text"
-          required={true}
-          defaultValue={namingConvention}
-          onChange={(e) =>
-            dispatch({
-              type: Action.SET_NAMING_CONVENTION,
-              payload: e.target.value,
-            })
-          }
-        />
-      </label>
-      <label className="label">
-        <span className="label-title">Rounding</span>
-        <span className="label-description">Control how many decimal places are shown in the output.</span>
-        <Input
-          type="number"
-          step={1}
-          min={0}
-          required={true}
-          defaultValue={roundingDecimalPlaces}
-          onChange={(e) =>
-            dispatch({
-              type: Action.SET_ROUNDING_DECIMAL_PLACES,
-              payload: Number(e.target.value),
-            })
-          }
-        />
-      </label>
-      <Checkbox
-        checked={shouldUseRems}
-        onChange={(e) =>
-          dispatch({
-            type: Action.SET_SHOULD_USE_REMS,
-            payload: e.target.checked,
-          })
-        }
-      >
-        Show output in rems
-      </Checkbox>
+      <GroupMinimum min={min} maxScreenWidth={max.screenWidth} dispatch={dispatch} />
+      <GroupMaximum max={max} minScreenWidth={min.screenWidth} dispatch={dispatch} />
+      <GroupModularSteps modularSteps={modularSteps} dispatch={dispatch} />
+      <GroupBaseModularStep baseModularStep={baseModularStep} dispatch={dispatch} />
+      <GroupNamingConvention namingConvention={namingConvention} dispatch={dispatch} />
+      <GroupRounding roundingDecimalPlaces={roundingDecimalPlaces} dispatch={dispatch} />
+      <GroupUseRems shouldUseRems={shouldUseRems} dispatch={dispatch} />
     </form>
   );
 };

--- a/src/_includes/components/GoogleFontsPicker/index.jsx
+++ b/src/_includes/components/GoogleFontsPicker/index.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { Delay } from '../constants';
+import Select from '../Select';
 
 /**
  * @typedef GoogleFontsPickerProps
@@ -35,13 +37,13 @@ const GoogleFontsPicker = (props) => {
   }, []);
 
   return (
-    <select ref={pickerRef} defaultValue={defaultValue} onChange={onChange}>
+    <Select ref={pickerRef} defaultValue={defaultValue} onChange={onChange} delay={Delay.LONG}>
       {fonts.map((fontFamily) => (
         <option key={fontFamily} value={fontFamily}>
           {fontFamily}
         </option>
       ))}
-    </select>
+    </Select>
   );
 };
 

--- a/src/_includes/components/GroupBaseModularStep/index.jsx
+++ b/src/_includes/components/GroupBaseModularStep/index.jsx
@@ -1,0 +1,29 @@
+import { Action } from '../constants';
+import Input from '../Input';
+
+/**
+ * @param {Pick<import('../typedefs').AppState, 'baseModularStep'> & { dispatch: import('../typedefs').AppDispatcher }} props
+ */
+const GroupBaseModularStep = (props) => {
+  const { baseModularStep, dispatch } = props;
+  return (
+    <label className="label">
+      <span className="label-title">Baseline modular step</span>
+      <span className="label-description">
+        Identify the name of the baseline font size step in your type scale. This must appear in the list entered above.
+      </span>
+      <Input
+        type="text"
+        required={true}
+        defaultValue={baseModularStep}
+        onChange={(e) =>
+          dispatch({
+            type: Action.SET_BASE_MODULAR_STEP,
+            payload: e.target.value,
+          })
+        }
+      />
+    </label>
+  );
+};
+export default GroupBaseModularStep;

--- a/src/_includes/components/Input/index.jsx
+++ b/src/_includes/components/Input/index.jsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import debounce from 'lodash/debounce';
+import { Delay } from '../constants';
 
 const specializedPropsByType = {
   number: {
@@ -7,21 +9,22 @@ const specializedPropsByType = {
 };
 
 /**
- * @param {React.HTMLProps<HTMLInputElement>} props
+ * @typedef InputProps
+ * @property {number} delay - the delay (in milliseconds) for the change event. Defaults to a short delay if not specified and `0` for checkboxes, radio buttons, and range inputs.
+ */
+
+/**
+ * @param {InputProps & React.HTMLProps<HTMLInputElement>} props
  */
 const Input = (props) => {
   const { onChange, type, step, ...otherProps } = props;
   const htmlStep = type === 'number' ? step ?? 'any' : undefined;
+  const delay = ['checkbox', 'radio', 'range'].includes(type) ? 0 : props.delay ?? Delay.SHORT;
   const [isValid, setIsValid] = useState(true);
 
-  return (
-    <input
-      {...otherProps}
-      {...specializedPropsByType[type]}
-      type={type}
-      step={htmlStep}
-      aria-invalid={!isValid}
-      onChange={(e) => {
+  const debouncedHandleChange = useMemo(
+    () => {
+      const handleChange = (e) => {
         const isValid = e.target.checkValidity();
         setIsValid(isValid);
         if (isValid) {
@@ -31,7 +34,25 @@ const Input = (props) => {
         } else {
           e.target.reportValidity();
         }
-      }}
+      };
+      // Sub-optimization: don't debounce if no delay
+      if (delay === 0) {
+        return handleChange;
+      }
+      return debounce(handleChange, delay);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [delay]
+  );
+
+  return (
+    <input
+      {...otherProps}
+      {...specializedPropsByType[type]}
+      type={type}
+      step={htmlStep}
+      aria-invalid={!isValid}
+      onChange={debouncedHandleChange}
     />
   );
 };

--- a/src/_includes/components/Preview/index.jsx
+++ b/src/_includes/components/Preview/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Input from '../Input';
 import RangeInput from '../RangeInput';
 import clsx from 'clsx';
@@ -28,12 +28,16 @@ const Preview = (props) => {
   }, []);
 
   /** @param {string} fontFamily - the name of the selected font */
-  const onFontSelected = async (fontFamily) => {
-    const link = getFontLinkTag('user-selected-font');
-    document.head.appendChild(link);
-    link.addEventListener('load', onLinkLoaded(fontFamily, previewText, setPreviewFont));
-    link.href = `https://fonts.googleapis.com/css2?family=${fontFamily.replace(/ /g, '+')}&display=swap`;
-  };
+  const onFontSelected = useCallback(
+    async (e) => {
+      const fontFamily = e.target.value;
+      const link = getFontLinkTag('user-selected-font');
+      document.head.appendChild(link);
+      link.addEventListener('load', onLinkLoaded(fontFamily, previewText, setPreviewFont));
+      link.href = `https://fonts.googleapis.com/css2?family=${fontFamily.replace(/ /g, '+')}&display=swap`;
+    },
+    [previewText]
+  );
 
   return (
     <section className={styles.preview}>
@@ -42,7 +46,7 @@ const Preview = (props) => {
         <RangeInput
           id="screen-width-range"
           label="Screen width (pixels)"
-          value={screenWidth}
+          defaultValue={screenWidth}
           onChange={(e) => setScreenWidth(Number(e.target.value))}
           min={0}
           // TODO: better pattern?
@@ -50,15 +54,17 @@ const Preview = (props) => {
         />
         <label className="label">
           <span className="label-title">Font family</span>
-          <GoogleFontsPicker
-            fonts={fonts}
-            defaultValue={previewFont}
-            onChange={(e) => onFontSelected(e.target.value)}
-          />
+          <GoogleFontsPicker fonts={fonts} defaultValue={previewFont} onChange={onFontSelected} />
         </label>
         <label className={clsx('label', styles['preview-text-label'])}>
           <span className="label-title">Preview text</span>
-          <Input type="text" required defaultValue={previewText} onChange={(e) => setPreviewText(e.target.value)} />
+          <Input
+            type="text"
+            required
+            defaultValue={previewText}
+            delay={0}
+            onChange={(e) => setPreviewText(e.target.value)}
+          />
         </label>
       </div>
       <div className="table-wrapper">

--- a/src/_includes/components/Preview/index.jsx
+++ b/src/_includes/components/Preview/index.jsx
@@ -6,20 +6,20 @@ import styles from './styles.module.scss';
 import GoogleFontsPicker from '../GoogleFontsPicker';
 import { getFontLinkTag, onLinkLoaded } from './utils';
 import { defaultFonts } from './constants';
+import { initialState } from '../constants';
 
 /**
  * @typedef PreviewProps
- * @property {{ min: import('../typedefs').BreakpointConfig; max: import('../typedefs').BreakpointConfig }} baseSizes
  * @property {import('../typedefs').TypeScale} typeScale - the type scale to preview
  * @property {string[]} fonts - all font families
  */
 
 /** @param {PreviewProps} props */
 const Preview = (props) => {
-  const { baseSizes, fonts, typeScale } = props;
+  const { fonts, typeScale } = props;
   const [previewText, setPreviewText] = useState('Almost before we knew it, we had left the ground');
   const [previewFont, setPreviewFont] = useState(defaultFonts[0]);
-  const [screenWidth, setScreenWidth] = useState(baseSizes.max.screenWidth);
+  const [screenWidth, setScreenWidth] = useState(initialState.max.screenWidth);
 
   useEffect(() => {
     // Since Slinkity uses SSR, this must be done on mount
@@ -107,4 +107,5 @@ const Preview = (props) => {
     </section>
   );
 };
+
 export default Preview;

--- a/src/_includes/components/RangeInput/index.jsx
+++ b/src/_includes/components/RangeInput/index.jsx
@@ -20,7 +20,7 @@ const RangeInput = (props) => {
       <div className={styles['range-display']}>
         <Input type="range" id={id} step={1} {...otherProps} />
         <label className="label" data-flow="horizontal">
-          Custom <Input type="number" step={1} {...otherProps} />
+          Custom <Input type="number" step={1} delay={0} {...otherProps} />
         </label>
       </div>
     </div>

--- a/src/_includes/components/Select/index.jsx
+++ b/src/_includes/components/Select/index.jsx
@@ -1,0 +1,29 @@
+import { forwardRef, useMemo } from 'react';
+import debounce from 'lodash/debounce';
+
+/**
+ * @typedef SelectProps
+ * @property {number} delay - the delay (in milliseconds) for the change event. Defaults to `0` (no delay).
+ */
+
+/**
+ * @type React.FC<SelectProps & Omit<React.HTMLProps<HTMLSelectElement>, 'ref'>>
+ */
+const Select = forwardRef((props, ref) => {
+  const { delay = 0, children, onChange, ...otherProps } = props;
+
+  const handleChange = useMemo(() => {
+    if (delay === 0) {
+      return onChange;
+    }
+    return debounce(onChange, delay);
+  }, [onChange, delay]);
+
+  return (
+    <select ref={ref} onChange={handleChange} {...otherProps}>
+      {children}
+    </select>
+  );
+});
+
+export default Select;

--- a/src/_includes/components/TypeScalePicker/index.jsx
+++ b/src/_includes/components/TypeScalePicker/index.jsx
@@ -1,4 +1,5 @@
 import { modularRatios } from '../constants';
+import Select from '../Select';
 
 /**
  * @typedef TypeScalePickerProps
@@ -15,7 +16,7 @@ const TypeScalePicker = (props) => {
   return (
     <label>
       Type scale ratio
-      <select defaultValue={ratio} onChange={onChange}>
+      <Select defaultValue={ratio} onChange={onChange}>
         {Object.entries(modularRatios).map(([key, { ratio }]) => {
           return (
             <option key={key} value={ratio}>
@@ -23,7 +24,7 @@ const TypeScalePicker = (props) => {
             </option>
           );
         })}
-      </select>
+      </Select>
     </label>
   );
 };

--- a/src/_includes/components/constants.js
+++ b/src/_includes/components/constants.js
@@ -33,6 +33,25 @@ export const modularRatios = {
   },
 };
 
+/** @type {import('./typedefs').AppState} */
+export const initialState = {
+  min: {
+    fontSize: 16,
+    screenWidth: 400,
+    modularRatio: modularRatios.majorThird.ratio,
+  },
+  max: {
+    fontSize: 19,
+    screenWidth: 1280,
+    modularRatio: modularRatios.perfectFourth.ratio,
+  },
+  modularSteps: ['sm', 'base', 'md', 'lg', 'xl', 'xxl', 'xxxl'],
+  baseModularStep: 'base',
+  namingConvention: 'font-size',
+  shouldUseRems: true,
+  roundingDecimalPlaces: 2,
+};
+
 export const Action = {
   SET_MIN: 'setMin',
   SET_MAX: 'setMax',

--- a/src/_includes/components/constants.js
+++ b/src/_includes/components/constants.js
@@ -42,3 +42,10 @@ export const Action = {
   SET_SHOULD_USE_REMS: 'setShouldUseRems',
   SET_ROUNDING_DECIMAL_PLACES: 'setRoundingDecimalPlaces',
 };
+
+/** Enum of delays in milliseconds, for consistency across event handlers. */
+export const Delay = {
+  SHORT: 150,
+  MEDIUM: 300,
+  LONG: 400,
+};

--- a/src/_includes/components/typedefs.js
+++ b/src/_includes/components/typedefs.js
@@ -44,4 +44,8 @@
  * @property {*} payload - the payload used to update the state
  */
 
+/**
+ * @typedef {React.Dispatch<AppAction>} AppDispatcher
+ */
+
 export {};


### PR DESCRIPTION
- Debounce input/select handlers by default. Allow overrides on a case-by-case basis.
- Clean up some props/state for the `Preview` component.
- Split form out into separate components in case we need to memo them later (from profiling, this doesn't seem to be worth it).