### PR TITLE
Use datalist + numeric input for type scale picker instead of select

### DIFF
--- a/src/_includes/components/FluidTypeScaleCalculator/Form/GroupMaximum/index.jsx
+++ b/src/_includes/components/FluidTypeScaleCalculator/Form/GroupMaximum/index.jsx
@@ -52,6 +52,7 @@ const GroupMaximum = (props) => {
           />
         </Label>
         <TypeScalePicker
+          id="type-scale-max"
           ratio={max.modularRatio}
           onChange={(e) => dispatch({ type: Action.SET_MAX, payload: { modularRatio: Number(e.target.value) } })}
         />

--- a/src/_includes/components/FluidTypeScaleCalculator/Form/GroupMinimum/index.jsx
+++ b/src/_includes/components/FluidTypeScaleCalculator/Form/GroupMinimum/index.jsx
@@ -52,6 +52,7 @@ const GroupMinimum = (props) => {
           />
         </Label>
         <TypeScalePicker
+          id="type-scale-min"
           ratio={min.modularRatio}
           onChange={(e) => dispatch({ type: Action.SET_MIN, payload: { modularRatio: Number(e.target.value) } })}
         />

--- a/src/_includes/components/FluidTypeScaleCalculator/TypeScalePicker/index.jsx
+++ b/src/_includes/components/FluidTypeScaleCalculator/TypeScalePicker/index.jsx
@@ -1,31 +1,32 @@
 import { modularRatios } from '../../constants';
+import Input from '../../Input';
 import Label from '../../Label';
-import Select from '../../Select';
 
 /**
  * @typedef TypeScalePickerProps
- * @property {ChangeEventHandler<HTMLSelectElement>} onChange - callback for when a type scale is clicked
+ * @property {ChangeEventHandler<HTMLInputElement>} onChange - callback for when a type scale is clicked
  * @property {number} ratio - the currently selected numerical ratio
  */
 
 /**
  * Dropdown menu for modular type scales
- * @param {TypeScalePickerProps} props
+ * @param {TypeScalePickerProps & React.HTMLProps<HTMLInputElement>} props
  */
 const TypeScalePicker = (props) => {
-  const { onChange, ratio } = props;
+  const { onChange, ratio, id } = props;
   return (
     <Label>
       Type scale ratio
-      <Select defaultValue={ratio} onChange={onChange}>
-        {Object.entries(modularRatios).map(([key, { ratio }]) => {
+      <Input type="number" step="any" list={id} min={0} defaultValue={ratio} onChange={onChange} required={true} />
+      <datalist id={id}>
+        {Object.entries(modularRatios).map(([key, { name, ratio }]) => {
           return (
             <option key={key} value={ratio}>
-              {ratio}
+              {name}
             </option>
           );
         })}
-      </Select>
+      </datalist>
     </Label>
   );
 };

--- a/styles/_reset.scss
+++ b/styles/_reset.scss
@@ -42,6 +42,19 @@ textarea {
   font-weight: var(--fw-body-regular);
 }
 
+input {
+  // Reset for datalist dropdown icon: https://stackoverflow.com/a/20941546/5323344
+  &::-webkit-calendar-picker-indicator {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  &[type="checkbox"] {
+    width: var(--sp-base);
+    height: var(--sp-base);
+  }
+}
+
 select {
   appearance: none;
   background-color: var(--color-surface-light);
@@ -55,11 +68,6 @@ select,
 input:where([type="number"], [type="text"]) {
   width: 100%;
   min-height: 46px;
-}
-
-input[type="checkbox"] {
-  width: var(--sp-base);
-  height: var(--sp-base);
 }
 
 :where(input,textarea,select,option) {


### PR DESCRIPTION
Datalist doesn't show in Firefox for numeric inputs (https://caniuse.com/datalist), but the input still works. This seemed like the path of least resistance for allowing custom inputs but also suggesting values natively. The alternative is to conditionally render an additional input for a custom input, but that seems a bit heavy handed.

Tested with NVDA and VoiceOver on:

- Chrome 97
- Firefox 96
- Safari 15.1

Works well!

Roughly what it looks like in Chrome/Edge/Safari:

![image](https://user-images.githubusercontent.com/19352442/150613881-74da5a58-d19f-43bb-95ab-2fc189b8ce40.png)
