### PR TITLE
UX/UI enhancements

### DIFF
--- a/src/_includes/components/Alert/index.jsx
+++ b/src/_includes/components/Alert/index.jsx
@@ -1,0 +1,11 @@
+/**
+ * @type {React.FC<React.HTMLProps<HTMLDivElement>>}
+ */
+export const Alert = (props) => {
+  const { children, ...otherProps } = props;
+  return (
+    <div role="alert" {...otherProps}>
+      {children}
+    </div>
+  );
+};

--- a/src/_includes/components/CopyToClipboardButton/index.jsx
+++ b/src/_includes/components/CopyToClipboardButton/index.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Alert } from '../Alert';
 import styles from './styles.module.scss';
 
 /**
@@ -14,30 +15,33 @@ const CopyToClipboardButton = (props) => {
   const { text, onClick, ...otherProps } = props;
   const [isCopied, setIsCopied] = useState(false);
   return (
-    <button
-      id="copy-to-clipboard-button"
-      type="button"
-      className={styles['copy-to-clipboard-button']}
-      onClick={() => {
-        window.navigator.clipboard.writeText(text);
-        setIsCopied(true);
-        onClick?.();
-        setTimeout(() => {
-          setIsCopied(false);
-        }, 2000);
-      }}
-      {...otherProps}
-    >
-      {isCopied ? (
-        <>
-          Copied! <span aria-hidden="true">🎉</span>
-        </>
-      ) : (
-        <>
-          Copy to clipboard <span aria-hidden="true">📋</span>
-        </>
-      )}
-    </button>
+    <>
+      <button
+        id="copy-to-clipboard-button"
+        type="button"
+        className={styles['copy-to-clipboard-button']}
+        onClick={() => {
+          window.navigator.clipboard.writeText(text);
+          setIsCopied(true);
+          onClick?.();
+          setTimeout(() => {
+            setIsCopied(false);
+          }, 2000);
+        }}
+        {...otherProps}
+      >
+        {isCopied ? (
+          <>
+            Copied! <span aria-hidden="true">🎉</span>
+          </>
+        ) : (
+          <>
+            Copy to clipboard <span aria-hidden="true">📋</span>
+          </>
+        )}
+      </button>
+      {isCopied && <Alert className="sr-only">Copied</Alert>}
+    </>
   );
 };
 

--- a/src/_includes/components/CopyToClipboardButton/styles.module.scss
+++ b/src/_includes/components/CopyToClipboardButton/styles.module.scss
@@ -1,5 +1,5 @@
 .copy-to-clipboard-button {
   width: 100%;
-  padding: 24px;
+  padding: var(--sp-lg);
   text-align: center;
 }

--- a/src/_includes/components/CopyToClipboardButton/styles.module.scss
+++ b/src/_includes/components/CopyToClipboardButton/styles.module.scss
@@ -1,5 +1,5 @@
 .copy-to-clipboard-button {
   width: 100%;
-  padding: var(--sp-lg);
+  padding: var(--sp-md);
   text-align: center;
 }

--- a/src/_includes/components/FluidTypeScaleCalculator/Form/GroupRounding/index.jsx
+++ b/src/_includes/components/FluidTypeScaleCalculator/Form/GroupRounding/index.jsx
@@ -1,6 +1,7 @@
 import { Action } from '../../../constants';
 import Input from '../../../Input';
 import Label from '../../../Label';
+import styles from './styles.module.scss';
 
 /**
  * @param {Pick<import("../../../typedefs").AppState, 'roundingDecimalPlaces'> & { dispatch: import("../../../typedefs").AppDispatcher } } props
@@ -8,8 +9,14 @@ import Label from '../../../Label';
 const GroupRounding = (props) => {
   const { roundingDecimalPlaces, dispatch } = props;
   return (
-    <Label title="Rounding" description="Control the maximum number of decimal places in the output.">
+    <div className={styles['group-rounding']}>
+      <Label
+        title="Rounding"
+        description="The maximum number of decimal places in the output."
+        htmlFor="group-rounding"
+      />
       <Input
+        id="group-rounding"
         type="number"
         step={1}
         min={0}
@@ -23,7 +30,7 @@ const GroupRounding = (props) => {
           })
         }
       />
-    </Label>
+    </div>
   );
 };
 export default GroupRounding;

--- a/src/_includes/components/FluidTypeScaleCalculator/Form/GroupRounding/styles.module.scss
+++ b/src/_includes/components/FluidTypeScaleCalculator/Form/GroupRounding/styles.module.scss
@@ -1,0 +1,6 @@
+.group-rounding {
+  display: grid;
+  align-items: end;
+  grid-auto-flow: column;
+  gap: var(--sp-xs);
+}

--- a/src/_includes/components/FluidTypeScaleCalculator/Output/index.jsx
+++ b/src/_includes/components/FluidTypeScaleCalculator/Output/index.jsx
@@ -22,7 +22,9 @@ const Output = (props) => {
   return (
     <aside className={styles.output}>
       <div className={styles['output-wrapper']}>
-        <output className={styles['output-code']}>{code}</output>
+        <output className={styles['output-code']}>
+          <code className={styles.code}>{code}</code>
+        </output>
       </div>
       <CopyToClipboardButton text={code} />
     </aside>

--- a/src/_includes/components/FluidTypeScaleCalculator/Output/styles.module.scss
+++ b/src/_includes/components/FluidTypeScaleCalculator/Output/styles.module.scss
@@ -17,12 +17,12 @@
     background-color: var(--color-surface-medium);
     white-space: pre;
     display: flex;
-    font-family: var(--ff-code);
-    font-weight: var(--fw-code-regular);
-    font-size: var(--sp-sm);
     overflow: auto;
     padding: var(--sp-lg);
     user-select: all;
-    line-height: 1.6;
   }
+}
+
+.code {
+  --line-height: 1.7;
 }

--- a/styles/_reset.scss
+++ b/styles/_reset.scss
@@ -3,7 +3,7 @@
   margin: 0;
   padding: 0;
 
-  --line-height: calc(2ex + 5px);
+  --line-height: calc(2ex + 6px);
   line-height: var(--line-height);
 }
 

--- a/styles/_utils.scss
+++ b/styles/_utils.scss
@@ -3,6 +3,16 @@
 
 // Generic utility classes that don't need to be CSS modules
 
+.sr-only {
+  position: absolute;
+  left: 0;
+  clip: rect(0, 0, 0, 0);
+
+  &:focus {
+    clip: auto;
+  }
+}
+
 .list {
   padding-inline-start: 1em;
   display: grid;


### PR DESCRIPTION
- Added an `Alert` component to communicate time-sensitive information to screen readers (e.g., copy-to-clipboard state).
- Nested `<code>`  as a child of the output and removed redundant styling set on the `output` element.
- Removed hard-coded padding from the copy-to-clipboard button and used a spacing variable instead.
- Cleaned up the styling for the rounding group.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/19352442/160122919-fd2330bb-e48f-4712-80be-d7a85f3feb71.png)|![image](https://user-images.githubusercontent.com/19352442/160123004-594e9916-fc9c-4d81-b066-b3e590bf2b3d.png)|