### PR TITLE
Better error handling

### DIFF
--- a/src/components/ErrorPage/ErrorPage.module.scss
+++ b/src/components/ErrorPage/ErrorPage.module.scss
@@ -1,0 +1,11 @@
+.error-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.error-banner {
+  display: grid;
+  place-content: center;
+  flex: 1 0 0;
+}

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,23 @@
+import { HTTPError } from '../../types';
+import HeroBanner from '../HeroBanner/HeroBanner';
+import Layout from '../Layout/Layout';
+import styles from './ErrorPage.module.scss';
+
+const ErrorPage = (props: HTTPError) => {
+  const { code, reasonPhrase, description } = props;
+  const title = `${code} ${reasonPhrase}`;
+  return (
+    <Layout
+      seoProps={{
+        title,
+        description,
+      }}
+      isBlockedFromIndexing={true}
+      className={styles['error-page']}
+    >
+      <HeroBanner title={title} subtitle={description} className={styles['error-banner']} />
+    </Layout>
+  );
+};
+
+export default ErrorPage;

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -1,21 +1,21 @@
+import escape from 'lodash/escape';
 import { HTTPError } from '../../types';
 import HeroBanner from '../HeroBanner/HeroBanner';
 import Layout from '../Layout/Layout';
 import styles from './ErrorPage.module.scss';
 
 const ErrorPage = (props: HTTPError) => {
-  const { code, reasonPhrase, description } = props;
-  const title = `${code} ${reasonPhrase}`;
+  const title = `${props.code} ${props.reasonPhrase}`;
   return (
     <Layout
       seoProps={{
         title,
-        description,
+        description: escape(props.description),
       }}
       isBlockedFromIndexing={true}
       className={styles['error-page']}
     >
-      <HeroBanner title={title} subtitle={description} className={styles['error-banner']} />
+      <HeroBanner title={title} subtitle={props.description} className={styles['error-banner']} />
     </Layout>
   );
 };

--- a/src/components/HeroBanner/HeroBanner.module.scss
+++ b/src/components/HeroBanner/HeroBanner.module.scss
@@ -7,7 +7,6 @@
 .title {
   font-size: var(--sp-xxxxl);
   font-weight: var(--fw-body-bold);
-  margin-bottom: var(--sp-base);
 }
 
 .subtitle {

--- a/src/components/HeroBanner/HeroBanner.tsx
+++ b/src/components/HeroBanner/HeroBanner.tsx
@@ -1,6 +1,8 @@
+import { HTMLProps } from 'react';
+import clsx from 'clsx';
 import styles from './HeroBanner.module.scss';
 
-export type HeroBannerProps = {
+export type HeroBannerProps = Pick<HTMLProps<HTMLDivElement>, 'className'> & {
   /** The title to render in the hero banner. */
   title: string;
   /** The subtitle to render below the title. */
@@ -10,7 +12,7 @@ export type HeroBannerProps = {
 const HeroBanner = (props: HeroBannerProps) => {
   const { title, subtitle } = props;
   return (
-    <header className={styles['hero-banner']}>
+    <header className={clsx(styles['hero-banner'], props.className)}>
       <h1 className={styles.title}>{title}</h1>
       {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
     </header>

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,6 +1,7 @@
 @import "../../../styles/functions";
 
 .layout {
+  min-height: 100%;
   display: grid;
   gap: var(--sp-xl);
   padding-top: clamped(48px, 100px);

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -32,7 +32,7 @@ const Layout: FC<LayoutProps> = (props) => {
   const ogImageUrl = toAbsoluteUrl('/assets/images/thumbnail.png');
 
   return (
-    <main className={clsx(styles.layout, 'container')}>
+    <main className={clsx(styles.layout, 'container', props.className)}>
       <Head>
         <title>{seoProps.title}</title>
         <meta name="description" content={seoProps.description} />

--- a/src/components/Layout/Layout.types.ts
+++ b/src/components/Layout/Layout.types.ts
@@ -12,4 +12,6 @@ export type LayoutProps = {
   seoProps?: SEOProps;
   /** Whether the page should be blocked from indexing. More info: https://developers.google.com/search/docs/advanced/crawling/block-indexing */
   isBlockedFromIndexing?: boolean;
+  /** Optional class names to style the page layout. */
+  className?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,3 +103,12 @@ export type WithFonts = {
   /** A list of fonts that users can choose from. */
   fonts: string[];
 };
+
+export type HTTPError = {
+  /** The HTTP status code for the error. */
+  code: number;
+  /** The reason phrase for the status code. */
+  reasonPhrase: string;
+  /** An extended description of the error. */
+  description: string;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,9 +29,12 @@ export const getGoogleFontLinkTagHref = (fontFamily: string) =>
 /** Returns `true` if the given string represents a number and `false` otherwise. Example: `isNumber('2')` returns `true`. */
 export const isNumber = (value: string) => !Number.isNaN(+value);
 
-/** Throws an error if the condition evaluates to `true`. */
-export const throwIf = (condition: boolean) => {
+/** Throws an error if the condition evaluates to `true`.
+ * @param {boolean} condition A boolean predicate condition to evaluate.
+ * @param {string} message An optional message to throw if the condition evaluates to `false`.
+ */
+export const throwIf = (condition: boolean, message?: string) => {
   if (condition) {
-    throw new Error();
+    throw new Error(message);
   }
 };

--- a/styles/_reset.scss
+++ b/styles/_reset.scss
@@ -16,6 +16,13 @@
   }
 }
 
+/* stylelint-disable-next-line selector-id-pattern */
+#__next,
+html,
+body {
+  height: 100%;
+}
+
 button,
 label,
 input,


### PR DESCRIPTION
Instead of redirecting to the home page, the app will now show an error page component with an appropriate HTTP status code, reason phrase, and description. This should make it easier to debug any user problems that arise when URL sharing goes to prod—because we're not redirecting, they can share the full URL in their ticket, but the error component also provides some helpful feedback so they can correct the mistake.

## Examples

`/calculate?minWidth=1280&maxWidth=1280`

![image](https://user-images.githubusercontent.com/19352442/162442653-1553c15c-e118-45a4-9c17-e7b79fd28d1b.png)

`/calculate?font=unrecognized`

![image](https://user-images.githubusercontent.com/19352442/162442895-6b96327c-8648-4e8c-84df-58ec7b782abc.png)

`/calculate?minFontSize=abc`

![image](https://user-images.githubusercontent.com/19352442/162443062-0b950849-5c6f-4d93-898e-b1dd51f491b7.png)
