### PR TITLE
Use a better pattern for validating query params

### DIFF
--- a/src/api/api.types.ts
+++ b/src/api/api.types.ts
@@ -1,0 +1,92 @@
+import { MapDiscriminatedUnion, QueryParamKey } from '../types';
+
+/** A query parameter with a value and a corresponding validator function to check the value. */
+export type ValidatedQueryParam<T> = {
+  /** The value parsed from the query string. */
+  value: T;
+  /** Throws if this query param's value is invalid.
+   * @param {QueryParam['id']} id The unique ID of this query param.
+   * @param {T} value The value to check for this query param.
+   * @param {QueryParamConfig} config The entire config that this query param is part of.
+   */
+  validate: (id: QueryParam['id'], value: T, config: QueryParamConfig) => void;
+};
+
+/** A query parameter that, when parsed, is expected to be of type `number`. */
+type NumericQueryParam = ValidatedQueryParam<number> & {
+  /** The minimum value this query parameter is allowed to have. */
+  min?: number;
+  /** The maximum value this query parameter is allowed to have. */
+  max?: number;
+};
+
+export type ParamMinFontSize = NumericQueryParam & {
+  id: QueryParamKey.minFontSize;
+};
+
+export type ParamMinScreenWidth = NumericQueryParam & {
+  id: QueryParamKey.minScreenWidth;
+};
+
+export type ParamMinRatio = NumericQueryParam & {
+  id: QueryParamKey.minRatio;
+};
+
+export type ParamMaxFontSize = NumericQueryParam & {
+  id: QueryParamKey.maxFontSize;
+};
+
+export type ParamMaxScreenWidth = NumericQueryParam & {
+  id: QueryParamKey.maxScreenWidth;
+};
+
+export type ParamMaxRatio = NumericQueryParam & {
+  id: QueryParamKey.maxRatio;
+};
+
+export type ParamTypeScaleSteps = ValidatedQueryParam<string[]> & {
+  id: QueryParamKey.allSteps;
+};
+
+export type ParamBaseTypeScaleStep = ValidatedQueryParam<string> & {
+  id: QueryParamKey.baseStep;
+};
+
+export type ParamNamingConvention = ValidatedQueryParam<string> & {
+  id: QueryParamKey.namingConvention;
+};
+
+export type ParamShouldUseRems = ValidatedQueryParam<boolean> & {
+  id: QueryParamKey.shouldUseRems;
+};
+
+export type ParamRoundingDecimalPlaces = NumericQueryParam & {
+  id: QueryParamKey.roundingDecimalPlaces;
+  min: number;
+  max: number;
+};
+
+export type ParamFontFamily = ValidatedQueryParam<string> & {
+  id: QueryParamKey.fontFamily;
+};
+
+export type QueryParam =
+  | ParamMinFontSize
+  | ParamMinScreenWidth
+  | ParamMinRatio
+  | ParamMaxFontSize
+  | ParamMaxScreenWidth
+  | ParamMaxRatio
+  | ParamTypeScaleSteps
+  | ParamBaseTypeScaleStep
+  | ParamNamingConvention
+  | ParamShouldUseRems
+  | ParamRoundingDecimalPlaces
+  | ParamFontFamily;
+
+/** Mapped type where they keys `K` correspond to shapes that extend `{ id: K }`. Defines a config for each query parameter. */
+export type QueryParamConfig = MapDiscriminatedUnion<QueryParam, 'id'>;
+
+/** Given an ID, extracts the constituent from a discriminated union type `T` that has a property of `id` matching `N`.
+ * Credit: https://stackoverflow.com/a/50499316/5323344 */
+export type NarrowById<T, N> = T extends { id: N } ? T : never;

--- a/src/api/api.types.ts
+++ b/src/api/api.types.ts
@@ -1,4 +1,5 @@
-import { MapDiscriminatedUnion, QueryParamKey } from '../types';
+import type { QueryParamKey } from '../types';
+import type { MapDiscriminatedUnion } from '../types.generics';
 
 /** A query parameter with a value and a corresponding validator function to check the value. */
 export type ValidatedQueryParam<T> = {
@@ -86,7 +87,3 @@ export type QueryParam =
 
 /** Mapped type where they keys `K` correspond to shapes that extend `{ id: K }`. Defines a config for each query parameter. */
 export type QueryParamConfig = MapDiscriminatedUnion<QueryParam, 'id'>;
-
-/** Given an ID, extracts the constituent from a discriminated union type `T` that has a property of `id` matching `N`.
- * Credit: https://stackoverflow.com/a/50499316/5323344 */
-export type NarrowById<T, N> = T extends { id: N } ? T : never;

--- a/src/api/api.utils.ts
+++ b/src/api/api.utils.ts
@@ -1,0 +1,135 @@
+import { ParsedUrlQuery } from 'querystring';
+import { COMMA_SEPARATED_LIST_REGEX } from '../components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.constants.';
+import { DEFAULT_FONT_FAMILY, initialFormState } from '../constants';
+import { QueryParamKey } from '../types';
+import { isNumber, throwIf } from '../utils';
+import { NarrowById, QueryParam, QueryParamConfig, ValidatedQueryParam } from './api.types';
+
+/** Returns the query parameter config entry corresponding to the param that has the specified ID/key. */
+export const getQueryParam = <K extends QueryParam['id']>(
+  queryParams: QueryParamConfig,
+  key: K
+): NarrowById<QueryParam, K> => queryParams[key];
+
+// TODO: pass in fallbacks as an option to make this easier to test.
+/** Parses query parameters from the given query and returns a config describing each param and its constraints.
+ * If a param is not present in the `ParsedUrlQuery`, it will default to a fallback.
+ */
+export const getQueryParamConfig = (queryString: ParsedUrlQuery, options: { fonts: string[] }): QueryParamConfig => {
+  const query = queryString as Record<QueryParamKey, string>;
+
+  /** Helper to return a query param by key, if it exists, and an empty string otherwise. */
+  const parseRawParam = (key: keyof typeof QueryParamKey): string | undefined => query[QueryParamKey[key]];
+
+  /** Helper that fetches the given key from query params, expecting to find a string that looks like a number. If the param does not exist,
+   * returns the fallback. If the param exists but is not of a numeric type, throws an error. Else, returns the parsed param as a number. */
+  const parseNumericParam = (key: keyof typeof QueryParamKey, fallback: number): number => {
+    const param = parseRawParam(key) ?? fallback;
+    return Number(param);
+  };
+
+  const queryParamConfig: QueryParamConfig = {
+    [QueryParamKey.minFontSize]: {
+      id: QueryParamKey.minFontSize,
+      value: parseNumericParam('minFontSize', initialFormState.min.fontSize),
+      validate: (id, value, _config) => {
+        throwIf(!isNumber(value), `${id} must be a number.`);
+      },
+    },
+    [QueryParamKey.minScreenWidth]: {
+      id: QueryParamKey.minScreenWidth,
+      value: parseNumericParam('minScreenWidth', initialFormState.min.screenWidth),
+      validate: (id, value, config) => {
+        const maxScreenWidth = getQueryParam<QueryParamKey.maxScreenWidth>(config, QueryParamKey.maxScreenWidth).value;
+        throwIf(!isNumber(value), `${id} must be a number.`);
+        throwIf(value >= maxScreenWidth, `${id} must be strictly less than ${QueryParamKey.maxScreenWidth}.`);
+      },
+    },
+    [QueryParamKey.minRatio]: {
+      id: QueryParamKey.minRatio,
+      value: parseNumericParam('minRatio', initialFormState.min.modularRatio),
+      validate: (id, value, _config) => throwIf(!isNumber(value), `${id} must be a number.`),
+    },
+    [QueryParamKey.maxFontSize]: {
+      id: QueryParamKey.maxFontSize,
+      value: parseNumericParam('maxFontSize', initialFormState.max.fontSize),
+      validate: (id, value, _config) => throwIf(!isNumber(value), `${id} must be a number`),
+    },
+    [QueryParamKey.maxScreenWidth]: {
+      id: QueryParamKey.maxScreenWidth,
+      value: parseNumericParam('maxScreenWidth', initialFormState.max.screenWidth),
+      validate: (id, value, config) => {
+        const minScreenWidth = getQueryParam<QueryParamKey.minScreenWidth>(config, QueryParamKey.minScreenWidth).value;
+        throwIf(!isNumber(value), `${id} must be a number.`);
+        throwIf(value <= minScreenWidth, `${id} must be strictly greater than ${QueryParamKey.minScreenWidth}.`);
+      },
+    },
+    [QueryParamKey.maxRatio]: {
+      id: QueryParamKey.maxRatio,
+      value: parseNumericParam('maxRatio', initialFormState.max.modularRatio),
+      validate: (id, value, _config) => throwIf(!isNumber(value), `${id} must be a number.`),
+    },
+    [QueryParamKey.allSteps]: {
+      id: QueryParamKey.allSteps,
+      value: parseRawParam('allSteps')?.split(',') ?? initialFormState.typeScaleSteps.all,
+      validate: (id, value, _config) => {
+        const isValid = COMMA_SEPARATED_LIST_REGEX.test(value.join(','));
+        throwIf(!isValid, `${id} must be a comma-separated list of step names.`);
+      },
+    },
+    [QueryParamKey.baseStep]: {
+      id: QueryParamKey.baseStep,
+      value: parseRawParam('baseStep') ?? initialFormState.typeScaleSteps.base,
+      validate: (id, value, config) => {
+        const allSteps = getQueryParam<QueryParamKey.allSteps>(config, QueryParamKey.allSteps).value;
+        throwIf(!allSteps.includes(value), `The base step '${value}' was not found in the list of all steps.`);
+      },
+    },
+    [QueryParamKey.namingConvention]: {
+      id: QueryParamKey.namingConvention,
+      value: parseRawParam('namingConvention') ?? initialFormState.namingConvention,
+      validate: (id, value, _config) => {
+        const isEmpty = !value.length;
+        throwIf(isEmpty, `${id} must be a non-empty string`);
+      },
+    },
+    [QueryParamKey.shouldUseRems]: {
+      id: QueryParamKey.shouldUseRems,
+      value: parseRawParam('shouldUseRems') === 'on',
+      validate: (_value, _config) => true,
+    },
+    [QueryParamKey.roundingDecimalPlaces]: {
+      id: QueryParamKey.roundingDecimalPlaces,
+      value: parseNumericParam('roundingDecimalPlaces', initialFormState.roundingDecimalPlaces),
+      validate: (id, value, config) => {
+        throwIf(!isNumber(value), `${id} must be a number.`);
+        const self = getQueryParam<QueryParamKey.roundingDecimalPlaces>(config, QueryParamKey.roundingDecimalPlaces);
+        const isInRange = value >= self.min && value <= self.max;
+        throwIf(!isInRange, `${id} must be at least ${self.min} and at most ${self.max}.`);
+      },
+      min: 0,
+      max: 5,
+    },
+    [QueryParamKey.fontFamily]: {
+      id: QueryParamKey.fontFamily,
+      value: parseRawParam('fontFamily') ?? DEFAULT_FONT_FAMILY,
+      validate: (id, value, _config) =>
+        throwIf(
+          !options.fonts.includes(value),
+          `${value} is not a recognized Google Font. Custom fonts are not supported.`
+        ),
+    },
+  };
+
+  return queryParamConfig;
+};
+
+/** Loops over all query params in the supplied config and runs each param's validator function.
+ * If any query param is invalid, it will throw an error with a descriptive message.
+ */
+export const validateQueryParams = (queryParamConfig: QueryParamConfig) => {
+  Object.values(queryParamConfig).forEach((param) => {
+    const validate = param.validate as ValidatedQueryParam<typeof param.value>['validate'];
+    validate(param.id, param.value, queryParamConfig);
+  });
+};

--- a/src/api/api.utils.ts
+++ b/src/api/api.utils.ts
@@ -2,8 +2,9 @@ import { ParsedUrlQuery } from 'querystring';
 import { COMMA_SEPARATED_LIST_REGEX } from '../components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.constants.';
 import { DEFAULT_FONT_FAMILY, initialFormState } from '../constants';
 import { QueryParamKey } from '../types';
+import type { NarrowById } from '../types.generics';
 import { isNumber, throwIf } from '../utils';
-import { NarrowById, QueryParam, QueryParamConfig, ValidatedQueryParam } from './api.types';
+import type { QueryParam, QueryParamConfig, ValidatedQueryParam } from './api.types';
 
 /** Returns the query parameter config entry corresponding to the param that has the specified ID/key. */
 export const getQueryParam = <K extends QueryParam['id']>(

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
@@ -1,4 +1,4 @@
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import LabelGroup from '../../../Label/LabelGroup/LabelGroup';
@@ -18,7 +18,7 @@ const GroupMaximum = () => {
         <Label>
           Base font size (pixels)
           <Input
-            name={FormDataKey.maxFontSize}
+            name={QueryParamKey.maxFontSize}
             type="number"
             required={true}
             min={0}
@@ -36,7 +36,7 @@ const GroupMaximum = () => {
         <Label>
           Screen width (pixels)
           <Input
-            name={FormDataKey.maxScreenWidth}
+            name={QueryParamKey.maxScreenWidth}
             type="number"
             required={true}
             min={state.min.screenWidth + 1}
@@ -52,7 +52,7 @@ const GroupMaximum = () => {
           />
         </Label>
         <TypeScalePicker
-          name={FormDataKey.maxRatio}
+          name={QueryParamKey.maxRatio}
           id="type-scale-max"
           ratio={state.max.modularRatio}
           onChange={(e) => dispatch({ type: 'setMax', payload: { modularRatio: e.target.valueAsNumber } })}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
@@ -1,4 +1,4 @@
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import LabelGroup from '../../../Label/LabelGroup/LabelGroup';
@@ -18,7 +18,7 @@ const GroupMinimum = () => {
           Base font size (pixels)
           <Input
             type="number"
-            name={FormDataKey.minFontSize}
+            name={QueryParamKey.minFontSize}
             required={true}
             min={0}
             defaultValue={state.min.fontSize}
@@ -35,7 +35,7 @@ const GroupMinimum = () => {
         <Label>
           Screen width (pixels)
           <Input
-            name={FormDataKey.minScreenWidth}
+            name={QueryParamKey.minScreenWidth}
             type="number"
             required={true}
             min={0}
@@ -52,7 +52,7 @@ const GroupMinimum = () => {
           />
         </Label>
         <TypeScalePicker
-          name={FormDataKey.minRatio}
+          name={QueryParamKey.minRatio}
           id="type-scale-min"
           ratio={state.min.modularRatio}
           onChange={(e) => dispatch({ type: 'setMin', payload: { modularRatio: e.target.valueAsNumber } })}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
@@ -1,4 +1,4 @@
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import { useFormState } from '../../FluidTypeScaleCalculator.context';
@@ -11,7 +11,7 @@ const GroupNamingConvention = () => {
       description="Prefixed to each modular step to create unique variable names."
     >
       <Input
-        name={FormDataKey.namingConvention}
+        name={QueryParamKey.namingConvention}
         type="text"
         required={true}
         defaultValue={state.namingConvention}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
@@ -1,4 +1,4 @@
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import { useFormState } from '../../FluidTypeScaleCalculator.context';
@@ -14,7 +14,7 @@ const GroupRounding = () => {
         htmlFor="group-rounding"
       />
       <Input
-        name={FormDataKey.roundingDecimalPlaces}
+        name={QueryParamKey.roundingDecimalPlaces}
         id="group-rounding"
         type="number"
         step={1}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
@@ -1,5 +1,5 @@
 import { Delay } from '../../../../constants';
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import LabelGroup from '../../../Label/LabelGroup/LabelGroup';
@@ -19,7 +19,7 @@ const GroupTypeScaleSteps = () => {
         <Label>
           All steps
           <Input
-            name={FormDataKey.allSteps}
+            name={QueryParamKey.allSteps}
             type="text"
             required
             spellCheck="false"
@@ -37,7 +37,7 @@ const GroupTypeScaleSteps = () => {
         <Label>
           Baseline step
           <Select
-            name={FormDataKey.baseStep}
+            name={QueryParamKey.baseStep}
             defaultValue={state.typeScaleSteps.base}
             onChange={(e) =>
               dispatch({

--- a/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
@@ -1,4 +1,4 @@
-import { FormDataKey } from '../../../../types';
+import { QueryParamKey } from '../../../../types';
 import Checkbox from '../../../Checkbox/Checkbox';
 import { useFormState } from '../../FluidTypeScaleCalculator.context';
 
@@ -6,7 +6,7 @@ const GroupUseRems = () => {
   const { state, dispatch } = useFormState();
   return (
     <Checkbox
-      name={FormDataKey.shouldUseRems}
+      name={QueryParamKey.shouldUseRems}
       checked={state.shouldUseRems}
       onChange={(e) =>
         dispatch({

--- a/src/components/GoogleFontsPicker/GoogleFontsPicker.tsx
+++ b/src/components/GoogleFontsPicker/GoogleFontsPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Delay } from '../../constants';
-import { FormDataKey, WithFonts } from '../../types';
+import { QueryParamKey, WithFonts } from '../../types';
 import { TYPE_SCALE_FORM_ID } from '../FluidTypeScaleCalculator/Form/Form.constants';
 import Select, { SelectProps } from '../Select/Select';
 
@@ -39,7 +39,7 @@ const GoogleFontsPicker = (props: GoogleFontsPickerProps) => {
   return (
     <Select
       form={TYPE_SCALE_FORM_ID}
-      name={FormDataKey.fontFamily}
+      name={QueryParamKey.fontFamily}
       ref={pickerRef}
       defaultValue={defaultValue}
       onChange={onChange}

--- a/src/types.generics.ts
+++ b/src/types.generics.ts
@@ -1,10 +1,10 @@
-/** Given a discriminated union of types `T`, returns the constituent that has `K` keys mapping to `V` values.
+/** Given a discriminated union of types `T`, extracts the constituent that has `K` keys mapping to `V` values.
  *
  * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
  *
  * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
  */
-export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = Extract<T, Record<K, V>>;
 
 /** Given a type `T` of the shape `{ [K]: string }`, where `K` is a key of `T`, returns a mapped type
  * mapping each value under that key to the corresponding discriminated type/constituent from `T`.

--- a/src/types.generics.ts
+++ b/src/types.generics.ts
@@ -1,0 +1,23 @@
+/** Given a discriminated union of types `T`, returns the constituent that has `K` keys mapping to `V` values.
+ *
+ * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
+ *
+ * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
+ */
+export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+
+/** Given a type `T` of the shape `{ [K]: string }`, where `K` is a key of `T`, returns a mapped type
+ * mapping each value under that key to the corresponding discriminated type/constituent from `T`.
+ * This is mainly useful when `T` is a discriminated union type.
+ *
+ * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
+ *
+ * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
+ */
+export type MapDiscriminatedUnion<T extends Record<K, string>, K extends keyof T> = {
+  [V in T[K]]: DiscriminateUnion<T, K, V>;
+};
+
+/** Given an ID, extracts the constituent from a discriminated union type `T` that has a property of `id` matching `N`.
+ * Credit: https://stackoverflow.com/a/50499316/5323344 */
+export type NarrowById<T, N> = T extends { id: N } ? T : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export type FormAction =
     };
 
 /** The name attributes for form inputs. Set on the individual form inputs but also used on the server side to read the data from query params. */
-export enum FormDataKey {
+export enum QueryParamKey {
   minFontSize = 'minFontSize',
   minScreenWidth = 'minWidth',
   minRatio = 'minRatio',
@@ -111,4 +111,24 @@ export type HTTPError = {
   reasonPhrase: string;
   /** An extended description of the error. */
   description: string;
+};
+
+/** Given a discriminated union of types `T`, returns the constituent that has `K` keys mapping to `V` values.
+ *
+ * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
+ *
+ * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
+ */
+export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+
+/** Given a type `T` of the shape `{ [K]: string }`, where `K` is a key of `T`, returns a mapped type
+ * mapping each value under that key to the corresponding discriminated type/constituent from `T`.
+ * This is mainly useful when `T` is a discriminated union type.
+ *
+ * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
+ *
+ * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
+ */
+export type MapDiscriminatedUnion<T extends Record<K, string>, K extends keyof T> = {
+  [V in T[K]]: DiscriminateUnion<T, K, V>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,23 +112,3 @@ export type HTTPError = {
   /** An extended description of the error. */
   description: string;
 };
-
-/** Given a discriminated union of types `T`, returns the constituent that has `K` keys mapping to `V` values.
- *
- * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
- *
- * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
- */
-export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
-
-/** Given a type `T` of the shape `{ [K]: string }`, where `K` is a key of `T`, returns a mapped type
- * mapping each value under that key to the corresponding discriminated type/constituent from `T`.
- * This is mainly useful when `T` is a discriminated union type.
- *
- * Docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
- *
- * Credit: https://stackoverflow.com/questions/50125893/typescript-derive-map-from-discriminated-union/50125960#50125960
- */
-export type MapDiscriminatedUnion<T extends Record<K, string>, K extends keyof T> = {
-  [V in T[K]]: DiscriminateUnion<T, K, V>;
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,8 +26,8 @@ export const getGoogleFontFamilies = async (): Promise<string[]> => {
 export const getGoogleFontLinkTagHref = (fontFamily: string) =>
   `https://fonts.googleapis.com/css2?family=${fontFamily.replace(/ /g, '+')}&display=swap`;
 
-/** Returns `true` if the given string represents a number and `false` otherwise. Example: `isNumber('2')` returns `true`. */
-export const isNumber = (value: string) => !Number.isNaN(+value);
+/** Returns `true` if the given number is a valid number. */
+export const isNumber = (value: number) => !Number.isNaN(value);
 
 /** Throws an error if the condition evaluates to `true`.
  * @param {boolean} condition A boolean predicate condition to evaluate.


### PR DESCRIPTION
- Defines types for each URL param we expect to find.
- Create a config for each param specifying its ID, the parsed value, and a validator function that checks the value.

This pattern should be more extensible and makes `getServerSideProps` easier to read.