### PR TITLE
Add more whitespace around sections and hide preview inputs in noscript environment

### DIFF
--- a/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.module.scss
+++ b/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.module.scss
@@ -1,4 +1,8 @@
 .type-scale-calculator {
   display: grid;
+  gap: var(--sp-xxxxl);
+}
+
+.type-scale-stack {
   gap: var(--sp-xl);
 }

--- a/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.tsx
+++ b/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.tsx
@@ -100,7 +100,7 @@ const FluidTypeScaleCalculator = (props: Props) => {
   return (
     <FormStateContext.Provider value={{ state, dispatch }}>
       <div className={styles['type-scale-calculator']}>
-        <Stack>
+        <Stack className={styles['type-scale-stack']}>
           <Form />
           <Output typeScale={typeScale} />
         </Stack>

--- a/src/components/FluidTypeScaleCalculator/Output/Output.module.scss
+++ b/src/components/FluidTypeScaleCalculator/Output/Output.module.scss
@@ -6,7 +6,7 @@
   @include desktop {
     align-self: flex-start;
     position: sticky;
-    top: var(--gap);
+    top: var(--sp-xl);
   }
 
   &-wrapper {

--- a/src/components/FluidTypeScaleCalculator/Preview/Preview.module.scss
+++ b/src/components/FluidTypeScaleCalculator/Preview/Preview.module.scss
@@ -5,6 +5,12 @@
   width: 100%;
   overflow: hidden;
   padding: 0 4px;
+  display: grid;
+  gap: var(--sp-xxl);
+
+  h2 {
+    margin: 0;
+  }
 
   table {
     --cell-padding: var(--sp-xs);
@@ -28,7 +34,6 @@
   grid-template-columns: minmax(0, 1fr);
   align-items: end;
   gap: var(--sp-base);
-  margin: var(--sp-xxl) 0;
   @include desktop {
     grid-template-columns: repeat(12, 1fr);
 

--- a/src/components/FluidTypeScaleCalculator/Preview/Preview.tsx
+++ b/src/components/FluidTypeScaleCalculator/Preview/Preview.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 import clsx from 'clsx';
+import Head from 'next/head';
 import { DEFAULT_FONT_FAMILY, initialFormState } from '../../../constants';
 import type { TypeScale, WithFonts } from '../../../types';
 import { getGoogleFontLinkTagHref } from '../../../utils';
@@ -45,9 +46,15 @@ const Preview = (props: Props) => {
           href={getGoogleFontLinkTagHref({ family: state.fontFamily, display: 'swap' })}
         />
       )}
+      <Head>
+        {/* Hide nonessential/JS-dependent inputs in noscript environment. They won't work anyway. */}
+        <noscript>
+          <style>{`.${styles['label-group']} { display: none !important; }`}</style>
+        </noscript>
+      </Head>
       <section className={styles.preview}>
         <h2>Preview your type scale</h2>
-        <div id="preview-inputs" className={styles['label-group']}>
+        <div className={styles['label-group']}>
           <Label title="Font family">
             <GoogleFontsPicker fonts={fonts} defaultValue={state.fontFamily} onChange={onFontSelected} />
           </Label>

--- a/src/components/HeroBanner/HeroBanner.module.scss
+++ b/src/components/HeroBanner/HeroBanner.module.scss
@@ -1,9 +1,5 @@
 @import "../../../styles/functions";
 
-.hero-banner {
-  padding: clamped(12px, 48px) 0;
-}
-
 .title {
   font-size: var(--sp-xxxxl);
   font-weight: var(--fw-body-bold);

--- a/src/components/HeroBanner/HeroBanner.tsx
+++ b/src/components/HeroBanner/HeroBanner.tsx
@@ -1,5 +1,4 @@
 import { HTMLProps } from 'react';
-import clsx from 'clsx';
 import styles from './HeroBanner.module.scss';
 
 export type HeroBannerProps = Pick<HTMLProps<HTMLDivElement>, 'className'> & {
@@ -12,7 +11,7 @@ export type HeroBannerProps = Pick<HTMLProps<HTMLDivElement>, 'className'> & {
 const HeroBanner = (props: HeroBannerProps) => {
   const { title, subtitle } = props;
   return (
-    <header className={clsx(styles['hero-banner'], props.className)}>
+    <header className={props.className}>
       <h1 className={styles.title}>{title}</h1>
       {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
     </header>

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -3,6 +3,6 @@
 .layout {
   min-height: 100%;
   display: grid;
-  gap: var(--sp-xl);
-  padding-top: clamped(48px, 100px);
+  gap: var(--sp-xxxxl);
+  padding-top: clamped(60px, 148px);
 }

--- a/src/components/Stack/Stack.module.scss
+++ b/src/components/Stack/Stack.module.scss
@@ -1,9 +1,8 @@
 @import "../../../styles/mixins";
 
 .stack {
-  --gap: var(--sp-xl);
   display: grid;
-  gap: var(--gap);
+  gap: var(--sp-xxxxl);
   grid-template-columns: minmax(0, 1fr);
   grid-auto-flow: row;
   @include desktop {


### PR DESCRIPTION
- Hides preview inputs in a noscript environment since they require JS to work anyway.
- Increases whitespace between discrete sections.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/19352442/162636117-04d81c79-ef9d-43ec-ad91-a262e8f5e7ec.png)|![image](https://user-images.githubusercontent.com/19352442/162636170-b8352910-2aa5-4a33-8f6f-64afcda032bb.png)|
|![image](https://user-images.githubusercontent.com/19352442/162636184-b50a638e-864a-49ac-b3af-d87528695beb.png)|![image](https://user-images.githubusercontent.com/19352442/162636195-0288e94c-fa07-468a-830d-9d3d81e5c576.png)|
