### PR TITLE
Performance and naming improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,4 +17,5 @@
     "source.fixAll.eslint": true,
     "source.fixAll.stylelint": true
   },
+  "editor.wordWrap": "on"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluid-type-scale-calculator",
   "description": "Generate fluid typography variables with a modular type scale.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "author": {
     "name": "Aleksandr Hovhannisyan",

--- a/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.context.ts
+++ b/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.context.ts
@@ -1,30 +1,30 @@
 import { createContext, useContext } from 'react';
-import { QUERY_PARAM_CONFIG } from '../../api/api.constants';
-import { QueryParamId } from '../../api/api.types';
+import { schema } from '../../schema/schema';
+import { QueryParamId } from '../../schema/schema.types';
 import { FormAction, FormState, WithDispatch } from './FluidTypeScaleCalculator.types';
 
 /** The initial values used to populate the app's form. */
 export const initialFormState: FormState = {
   min: {
-    fontSize: QUERY_PARAM_CONFIG[QueryParamId.minFontSize].default,
-    screenWidth: QUERY_PARAM_CONFIG[QueryParamId.minWidth].default,
-    ratio: QUERY_PARAM_CONFIG[QueryParamId.minRatio].default,
+    fontSize: schema[QueryParamId.minFontSize].default,
+    screenWidth: schema[QueryParamId.minWidth].default,
+    ratio: schema[QueryParamId.minRatio].default,
   },
   max: {
-    fontSize: QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].default,
-    screenWidth: QUERY_PARAM_CONFIG[QueryParamId.maxWidth].default,
-    ratio: QUERY_PARAM_CONFIG[QueryParamId.maxRatio].default,
+    fontSize: schema[QueryParamId.maxFontSize].default,
+    screenWidth: schema[QueryParamId.maxWidth].default,
+    ratio: schema[QueryParamId.maxRatio].default,
   },
   typeScaleSteps: {
-    all: QUERY_PARAM_CONFIG[QueryParamId.allSteps].default,
-    base: QUERY_PARAM_CONFIG[QueryParamId.baseStep].default,
+    all: schema[QueryParamId.allSteps].default,
+    base: schema[QueryParamId.baseStep].default,
   },
-  namingConvention: QUERY_PARAM_CONFIG[QueryParamId.namingConvention].default,
-  shouldIncludeFallbacks: QUERY_PARAM_CONFIG[QueryParamId.shouldIncludeFallbacks].default,
-  shouldUseRems: QUERY_PARAM_CONFIG[QueryParamId.shouldUseRems].default,
-  remValueInPx: QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].default,
-  roundingDecimalPlaces: QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].default,
-  fontFamily: QUERY_PARAM_CONFIG[QueryParamId.previewFont].default,
+  namingConvention: schema[QueryParamId.namingConvention].default,
+  shouldIncludeFallbacks: schema[QueryParamId.shouldIncludeFallbacks].default,
+  shouldUseRems: schema[QueryParamId.shouldUseRems].default,
+  remValueInPx: schema[QueryParamId.remValueInPx].default,
+  roundingDecimalPlaces: schema[QueryParamId.roundingDecimalPlaces].default,
+  fontFamily: schema[QueryParamId.previewFont].default,
 };
 
 /** Given the previous app state and a dispatched action, returns the newly transformed state.
@@ -63,8 +63,8 @@ export const formStateReducer = (state: FormState, action: FormAction): FormStat
       return { ...state, remValueInPx: action.payload };
     }
     case 'setRoundingDecimalPlaces': {
-      const min = QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].min;
-      const max = QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].max;
+      const min = schema[QueryParamId.roundingDecimalPlaces].min;
+      const max = schema[QueryParamId.roundingDecimalPlaces].max;
       // To prevent client-side errors (e.g., because we can't rounding to negative decimal places or it'll throw an error)
       const roundingDecimalPlaces = Math.max(Math.min(action.payload, max), min);
       return { ...state, roundingDecimalPlaces };

--- a/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.types.ts
+++ b/src/components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.types.ts
@@ -27,44 +27,62 @@ export type FormState = {
   fontFamily: string;
 };
 
+export type ActionSetMin = {
+  type: 'setMin';
+  payload: Partial<FormState['min']>;
+};
+
+export type ActionSetMax = {
+  type: 'setMax';
+  payload: Partial<FormState['max']>;
+};
+
+export type ActionSetTypeScaleSteps = {
+  type: 'setTypeScaleSteps';
+  payload: Partial<FormState['typeScaleSteps']>;
+};
+
+export type ActionSetNamingConvention = {
+  type: 'setNamingConvention';
+  payload: FormState['namingConvention'];
+};
+
+export type ActionSetShouldIncludeFallbacks = {
+  type: 'setShouldIncludeFallbacks';
+  payload: FormState['shouldIncludeFallbacks'];
+};
+
+export type ActionSetShouldUseRems = {
+  type: 'setShouldUseRems';
+  payload: FormState['shouldUseRems'];
+};
+
+export type ActionSetRemValueInPx = {
+  type: 'setRemValueInPx';
+  payload: FormState['remValueInPx'];
+};
+
+export type ActionSetRoundingDecimalPlaces = {
+  type: 'setRoundingDecimalPlaces';
+  payload: FormState['roundingDecimalPlaces'];
+};
+
+export type ActionSetFontFamily = {
+  type: 'setFontFamily';
+  payload: FormState['fontFamily'];
+};
+
 /** An action that can be dispatched to update the app state. */
 export type FormAction =
-  | {
-      type: 'setMin';
-      payload: Partial<FormState['min']>;
-    }
-  | {
-      type: 'setMax';
-      payload: Partial<FormState['max']>;
-    }
-  | {
-      type: 'setTypeScaleSteps';
-      payload: Partial<FormState['typeScaleSteps']>;
-    }
-  | {
-      type: 'setNamingConvention';
-      payload: FormState['namingConvention'];
-    }
-  | {
-      type: 'setShouldIncludeFallbacks';
-      payload: FormState['shouldIncludeFallbacks'];
-    }
-  | {
-      type: 'setShouldUseRems';
-      payload: FormState['shouldUseRems'];
-    }
-  | {
-      type: 'setRemValueInPx';
-      payload: FormState['remValueInPx'];
-    }
-  | {
-      type: 'setRoundingDecimalPlaces';
-      payload: FormState['roundingDecimalPlaces'];
-    }
-  | {
-      type: 'setFontFamily';
-      payload: FormState['fontFamily'];
-    };
+  | ActionSetMin
+  | ActionSetMax
+  | ActionSetTypeScaleSteps
+  | ActionSetNamingConvention
+  | ActionSetShouldIncludeFallbacks
+  | ActionSetShouldUseRems
+  | ActionSetRemValueInPx
+  | ActionSetRoundingDecimalPlaces
+  | ActionSetFontFamily;
 
 export type WithDispatch = {
   /** A dispatch function to update the app state. */

--- a/src/components/FluidTypeScaleCalculator/Form/GroupIncludeFallbacks/GroupIncludeFallbacks.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupIncludeFallbacks/GroupIncludeFallbacks.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { QueryParamId } from '../../../../api/api.types';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import type { ActionSetShouldIncludeFallbacks, FormState } from '../../FluidTypeScaleCalculator.types';

--- a/src/components/FluidTypeScaleCalculator/Form/GroupIncludeFallbacks/GroupIncludeFallbacks.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupIncludeFallbacks/GroupIncludeFallbacks.tsx
@@ -1,10 +1,17 @@
+import { memo } from 'react';
 import { QueryParamId } from '../../../../api/api.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetShouldIncludeFallbacks, FormState } from '../../FluidTypeScaleCalculator.types';
 
-const GroupIncludeFallbacks = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'shouldIncludeFallbacks'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetShouldIncludeFallbacks['payload']) => void;
+};
+
+const GroupIncludeFallbacks = (props: Props) => {
+  const { shouldIncludeFallbacks, onChange } = props;
+
   return (
     <Label
       title="Include fallback CSS"
@@ -14,16 +21,11 @@ const GroupIncludeFallbacks = () => {
       <Input
         type="checkbox"
         name={QueryParamId.shouldIncludeFallbacks}
-        checked={state.shouldIncludeFallbacks}
-        onChange={(e) =>
-          dispatch({
-            type: 'setShouldIncludeFallbacks',
-            payload: e.target.checked,
-          })
-        }
+        checked={shouldIncludeFallbacks}
+        onChange={(e) => onChange(e.target.checked)}
       />
     </Label>
   );
 };
 
-export default GroupIncludeFallbacks;
+export default memo(GroupIncludeFallbacks);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
-import { QueryParamId } from '../../../../api/api.types';
+import { schema } from '../../../../schema/schema';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
@@ -28,8 +28,8 @@ const GroupMaximum = (props: Props) => {
           name={QueryParamId.maxFontSize}
           type="number"
           required={true}
-          min={QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].min}
-          max={QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].max}
+          min={schema[QueryParamId.maxFontSize].min}
+          max={schema[QueryParamId.maxFontSize].max}
           defaultValue={max.fontSize}
           onChange={(e) =>
             onChange({
@@ -45,7 +45,7 @@ const GroupMaximum = (props: Props) => {
           type="number"
           required={true}
           min={minScreenWidth}
-          max={QUERY_PARAM_CONFIG[QueryParamId.maxWidth].max}
+          max={schema[QueryParamId.maxWidth].max}
           defaultValue={max.screenWidth}
           onChange={(e) =>
             onChange({
@@ -58,8 +58,8 @@ const GroupMaximum = (props: Props) => {
         name={QueryParamId.maxRatio}
         id="type-scale-max"
         ratio={max.ratio}
-        min={QUERY_PARAM_CONFIG[QueryParamId.maxRatio].min}
-        max={QUERY_PARAM_CONFIG[QueryParamId.maxRatio].max}
+        min={schema[QueryParamId.maxRatio].min}
+        max={schema[QueryParamId.maxRatio].max}
         onChange={(e) => onChange({ ratio: e.target.valueAsNumber })}
       />
     </Fieldset>

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMaximum/GroupMaximum.tsx
@@ -1,13 +1,21 @@
+import { memo } from 'react';
 import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
 import { QueryParamId } from '../../../../api/api.types';
 import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetMax, FormState } from '../../FluidTypeScaleCalculator.types';
 import TypeScalePicker from '../../TypeScalePicker/TypeScalePicker';
 
-const GroupMaximum = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'max'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetMax['payload']) => void;
+  /** The minimum allowed value for the screen width input. */
+  minScreenWidth: FormState['min']['screenWidth'];
+};
+
+const GroupMaximum = (props: Props) => {
+  const { max, minScreenWidth, onChange } = props;
 
   return (
     <Fieldset
@@ -22,13 +30,10 @@ const GroupMaximum = () => {
           required={true}
           min={QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].min}
           max={QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].max}
-          defaultValue={state.max.fontSize}
+          defaultValue={max.fontSize}
           onChange={(e) =>
-            dispatch({
-              type: 'setMax',
-              payload: {
-                fontSize: e.target.valueAsNumber,
-              },
+            onChange({
+              fontSize: e.target.valueAsNumber,
             })
           }
         />
@@ -39,15 +44,12 @@ const GroupMaximum = () => {
           name={QueryParamId.maxWidth}
           type="number"
           required={true}
-          min={state.min.screenWidth + 1}
+          min={minScreenWidth}
           max={QUERY_PARAM_CONFIG[QueryParamId.maxWidth].max}
-          defaultValue={state.max.screenWidth}
+          defaultValue={max.screenWidth}
           onChange={(e) =>
-            dispatch({
-              type: 'setMax',
-              payload: {
-                screenWidth: e.target.valueAsNumber,
-              },
+            onChange({
+              screenWidth: e.target.valueAsNumber,
             })
           }
         />
@@ -55,13 +57,13 @@ const GroupMaximum = () => {
       <TypeScalePicker
         name={QueryParamId.maxRatio}
         id="type-scale-max"
-        ratio={state.max.ratio}
+        ratio={max.ratio}
         min={QUERY_PARAM_CONFIG[QueryParamId.maxRatio].min}
         max={QUERY_PARAM_CONFIG[QueryParamId.maxRatio].max}
-        onChange={(e) => dispatch({ type: 'setMax', payload: { ratio: e.target.valueAsNumber } })}
+        onChange={(e) => onChange({ ratio: e.target.valueAsNumber })}
       />
     </Fieldset>
   );
 };
 
-export default GroupMaximum;
+export default memo(GroupMaximum);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
-import { QueryParamId } from '../../../../api/api.types';
+import { schema } from '../../../../schema/schema';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
@@ -28,8 +28,8 @@ const GroupMinimum = (props: Props) => {
           name={QueryParamId.minFontSize}
           type="number"
           required={true}
-          min={QUERY_PARAM_CONFIG[QueryParamId.minFontSize].min}
-          max={QUERY_PARAM_CONFIG[QueryParamId.minFontSize].max}
+          min={schema[QueryParamId.minFontSize].min}
+          max={schema[QueryParamId.minFontSize].max}
           defaultValue={min.fontSize}
           onChange={(e) =>
             onChange({
@@ -44,7 +44,7 @@ const GroupMinimum = (props: Props) => {
           name={QueryParamId.minWidth}
           type="number"
           required={true}
-          min={QUERY_PARAM_CONFIG[QueryParamId.minWidth].min}
+          min={schema[QueryParamId.minWidth].min}
           max={maxScreenWidth}
           defaultValue={min.screenWidth}
           onChange={(e) =>
@@ -58,8 +58,8 @@ const GroupMinimum = (props: Props) => {
         name={QueryParamId.minRatio}
         id="type-scale-min"
         ratio={min.ratio}
-        min={QUERY_PARAM_CONFIG[QueryParamId.minRatio].min}
-        max={QUERY_PARAM_CONFIG[QueryParamId.minRatio].max}
+        min={schema[QueryParamId.minRatio].min}
+        max={schema[QueryParamId.minRatio].max}
         onChange={(e) => onChange({ ratio: e.target.valueAsNumber })}
       />
     </Fieldset>

--- a/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupMinimum/GroupMinimum.tsx
@@ -1,13 +1,22 @@
+import { memo } from 'react';
 import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
 import { QueryParamId } from '../../../../api/api.types';
 import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetMin, FormState } from '../../FluidTypeScaleCalculator.types';
 import TypeScalePicker from '../../TypeScalePicker/TypeScalePicker';
 
-const GroupMinimum = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'min'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetMin['payload']) => void;
+  /** The maximum allowed value for the screen width input. */
+  maxScreenWidth: FormState['max']['screenWidth'];
+};
+
+const GroupMinimum = (props: Props) => {
+  const { min, maxScreenWidth, onChange } = props;
+
   return (
     <Fieldset
       title="Minimum (Mobile)"
@@ -21,13 +30,10 @@ const GroupMinimum = () => {
           required={true}
           min={QUERY_PARAM_CONFIG[QueryParamId.minFontSize].min}
           max={QUERY_PARAM_CONFIG[QueryParamId.minFontSize].max}
-          defaultValue={state.min.fontSize}
+          defaultValue={min.fontSize}
           onChange={(e) =>
-            dispatch({
-              type: 'setMin',
-              payload: {
-                fontSize: e.target.valueAsNumber,
-              },
+            onChange({
+              fontSize: e.target.valueAsNumber,
             })
           }
         />
@@ -39,14 +45,11 @@ const GroupMinimum = () => {
           type="number"
           required={true}
           min={QUERY_PARAM_CONFIG[QueryParamId.minWidth].min}
-          max={state.max.screenWidth - 1}
-          defaultValue={state.min.screenWidth}
+          max={maxScreenWidth}
+          defaultValue={min.screenWidth}
           onChange={(e) =>
-            dispatch({
-              type: 'setMin',
-              payload: {
-                screenWidth: e.target.valueAsNumber,
-              },
+            onChange({
+              screenWidth: e.target.valueAsNumber,
             })
           }
         />
@@ -54,13 +57,13 @@ const GroupMinimum = () => {
       <TypeScalePicker
         name={QueryParamId.minRatio}
         id="type-scale-min"
-        ratio={state.min.ratio}
+        ratio={min.ratio}
         min={QUERY_PARAM_CONFIG[QueryParamId.minRatio].min}
         max={QUERY_PARAM_CONFIG[QueryParamId.minRatio].max}
-        onChange={(e) => dispatch({ type: 'setMin', payload: { ratio: e.target.valueAsNumber } })}
+        onChange={(e) => onChange({ ratio: e.target.valueAsNumber })}
       />
     </Fieldset>
   );
 };
 
-export default GroupMinimum;
+export default memo(GroupMinimum);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { QueryParamId } from '../../../../api/api.types';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import type { ActionSetNamingConvention, FormState } from '../../FluidTypeScaleCalculator.types';

--- a/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupNamingConvention/GroupNamingConvention.tsx
@@ -1,10 +1,16 @@
+import { memo } from 'react';
 import { QueryParamId } from '../../../../api/api.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetNamingConvention, FormState } from '../../FluidTypeScaleCalculator.types';
 
-const GroupNamingConvention = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'namingConvention'> & {
+  /** Function to update the value for this input. */
+  onChange: (action: ActionSetNamingConvention['payload']) => void;
+};
+
+const GroupNamingConvention = (props: Props) => {
+  const { namingConvention, onChange } = props;
   return (
     <Label title="Variable prefix" description="Use whatever naming convention you prefer." layout="to-horizontal">
       <Input
@@ -12,17 +18,12 @@ const GroupNamingConvention = () => {
         type="text"
         size={10}
         required={true}
-        defaultValue={state.namingConvention}
+        defaultValue={namingConvention}
         delay={0}
-        onChange={(e) =>
-          dispatch({
-            type: 'setNamingConvention',
-            payload: e.target.value,
-          })
-        }
+        onChange={(e) => onChange(e.target.value)}
       />
     </Label>
   );
 };
 
-export default GroupNamingConvention;
+export default memo(GroupNamingConvention);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupRemValueInPx/GroupRemValueInPx.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupRemValueInPx/GroupRemValueInPx.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
-import { QueryParamId } from '../../../../api/api.types';
+import { schema } from '../../../../schema/schema';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import type { ActionSetRemValueInPx, FormState } from '../../FluidTypeScaleCalculator.types';
@@ -25,8 +25,8 @@ const GroupRemValueInPx = (props: Props) => {
         className={styles['rem-input']}
         type="number"
         step={1}
-        min={QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].min}
-        max={QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].max}
+        min={schema[QueryParamId.remValueInPx].min}
+        max={schema[QueryParamId.remValueInPx].max}
         defaultValue={remValueInPx}
         required={true}
         onChange={(e) => onChange(e.target.valueAsNumber)}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupRemValueInPx/GroupRemValueInPx.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupRemValueInPx/GroupRemValueInPx.tsx
@@ -1,12 +1,19 @@
+import { memo } from 'react';
 import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
 import { QueryParamId } from '../../../../api/api.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetRemValueInPx, FormState } from '../../FluidTypeScaleCalculator.types';
 import styles from './GroupRemValueInPx.module.scss';
 
-const GroupRemValueInPx = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'remValueInPx'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetRemValueInPx['payload']) => void;
+};
+
+const GroupRemValueInPx = (props: Props) => {
+  const { remValueInPx, onChange } = props;
+
   return (
     <Label
       title="Rem value (pixels)"
@@ -20,16 +27,11 @@ const GroupRemValueInPx = () => {
         step={1}
         min={QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].min}
         max={QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].max}
-        defaultValue={state.remValueInPx}
+        defaultValue={remValueInPx}
         required={true}
-        onChange={(e) =>
-          dispatch({
-            type: 'setRemValueInPx',
-            payload: e.target.valueAsNumber,
-          })
-        }
+        onChange={(e) => onChange(e.target.valueAsNumber)}
       />
     </Label>
   );
 };
-export default GroupRemValueInPx;
+export default memo(GroupRemValueInPx);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
-import { QueryParamId } from '../../../../api/api.types';
+import { schema } from '../../../../schema/schema';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import type { ActionSetRoundingDecimalPlaces, FormState } from '../../FluidTypeScaleCalculator.types';
@@ -20,8 +20,8 @@ const GroupRounding = (props: Props) => {
         className={styles['rounding-input']}
         type="number"
         step={1}
-        min={QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].min}
-        max={QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].max}
+        min={schema[QueryParamId.roundingDecimalPlaces].min}
+        max={schema[QueryParamId.roundingDecimalPlaces].max}
         required={true}
         defaultValue={roundingDecimalPlaces}
         onChange={(e) => onChange(e.target.valueAsNumber)}

--- a/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupRounding/GroupRounding.tsx
@@ -1,12 +1,18 @@
+import { memo } from 'react';
 import { QUERY_PARAM_CONFIG } from '../../../../api/api.constants';
 import { QueryParamId } from '../../../../api/api.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetRoundingDecimalPlaces, FormState } from '../../FluidTypeScaleCalculator.types';
 import styles from './GroupRounding.module.scss';
 
-const GroupRounding = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'roundingDecimalPlaces'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetRoundingDecimalPlaces['payload']) => void;
+};
+
+const GroupRounding = (props: Props) => {
+  const { roundingDecimalPlaces, onChange } = props;
   return (
     <Label title="Rounding" description="The maximum number of decimal places in the output." layout="to-horizontal">
       <Input
@@ -17,15 +23,10 @@ const GroupRounding = () => {
         min={QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].min}
         max={QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].max}
         required={true}
-        defaultValue={state.roundingDecimalPlaces}
-        onChange={(e) =>
-          dispatch({
-            type: 'setRoundingDecimalPlaces',
-            payload: e.target.valueAsNumber,
-          })
-        }
+        defaultValue={roundingDecimalPlaces}
+        onChange={(e) => onChange(e.target.valueAsNumber)}
       />
     </Label>
   );
 };
-export default GroupRounding;
+export default memo(GroupRounding);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { QueryParamId } from '../../../../api/api.types';
 import { COMMA_SEPARATED_LIST_REGEX, Delay } from '../../../../constants';
 import { toCommaSeparatedList } from '../../../../utils';
@@ -5,10 +6,16 @@ import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import Select from '../../../Select/Select';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetTypeScaleSteps, FormState } from '../../FluidTypeScaleCalculator.types';
 
-const GroupTypeScaleSteps = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'typeScaleSteps'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetTypeScaleSteps['payload']) => void;
+};
+
+const GroupTypeScaleSteps = (props: Props) => {
+  const { typeScaleSteps, onChange } = props;
+
   return (
     <Fieldset
       title="Type scale"
@@ -23,12 +30,11 @@ const GroupTypeScaleSteps = () => {
           required
           spellCheck="false"
           pattern={COMMA_SEPARATED_LIST_REGEX.source}
-          defaultValue={state.typeScaleSteps.all.join(',')}
+          defaultValue={typeScaleSteps.all.join(',')}
           delay={Delay.MEDIUM}
           onChange={(e) =>
-            dispatch({
-              type: 'setTypeScaleSteps',
-              payload: { all: toCommaSeparatedList(e.target.value) },
+            onChange({
+              all: toCommaSeparatedList(e.target.value),
             })
           }
         />
@@ -37,15 +43,10 @@ const GroupTypeScaleSteps = () => {
         Baseline step
         <Select
           name={QueryParamId.baseStep}
-          defaultValue={state.typeScaleSteps.base}
-          onChange={(e) =>
-            dispatch({
-              type: 'setTypeScaleSteps',
-              payload: { base: e.target.value },
-            })
-          }
+          defaultValue={typeScaleSteps.base}
+          onChange={(e) => onChange({ base: e.target.value })}
         >
-          {state.typeScaleSteps.all.map((step) => (
+          {typeScaleSteps.all.map((step) => (
             <option key={step} value={step}>
               {step}
             </option>
@@ -56,4 +57,4 @@ const GroupTypeScaleSteps = () => {
   );
 };
 
-export default GroupTypeScaleSteps;
+export default memo(GroupTypeScaleSteps);

--- a/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupTypeScaleSteps/GroupTypeScaleSteps.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { QueryParamId } from '../../../../api/api.types';
 import { COMMA_SEPARATED_LIST_REGEX, Delay } from '../../../../constants';
+import { QueryParamId } from '../../../../schema/schema.types';
 import { toCommaSeparatedList } from '../../../../utils';
 import Fieldset from '../../../Fieldset/Fieldset';
 import Input from '../../../Input/Input';

--- a/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { QueryParamId } from '../../../../api/api.types';
+import { QueryParamId } from '../../../../schema/schema.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
 import type { ActionSetShouldUseRems, FormState } from '../../FluidTypeScaleCalculator.types';

--- a/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
+++ b/src/components/FluidTypeScaleCalculator/Form/GroupUseRems/GroupUseRems.tsx
@@ -1,10 +1,17 @@
+import { memo } from 'react';
 import { QueryParamId } from '../../../../api/api.types';
 import Input from '../../../Input/Input';
 import Label from '../../../Label/Label';
-import { useFormState } from '../../FluidTypeScaleCalculator.context';
+import type { ActionSetShouldUseRems, FormState } from '../../FluidTypeScaleCalculator.types';
 
-const GroupUseRems = () => {
-  const { state, dispatch } = useFormState();
+type Props = Pick<FormState, 'shouldUseRems'> & {
+  /** Function to update the value for this input. */
+  onChange: (payload: ActionSetShouldUseRems['payload']) => void;
+};
+
+const GroupUseRems = (props: Props) => {
+  const { shouldUseRems, onChange } = props;
+
   return (
     <Label
       title="Show output in rems"
@@ -14,16 +21,11 @@ const GroupUseRems = () => {
       <Input
         type="checkbox"
         name={QueryParamId.shouldUseRems}
-        checked={state.shouldUseRems}
-        onChange={(e) =>
-          dispatch({
-            type: 'setShouldUseRems',
-            payload: e.target.checked,
-          })
-        }
+        checked={shouldUseRems}
+        onChange={(e) => onChange(e.target.checked)}
       />
     </Label>
   );
 };
 
-export default GroupUseRems;
+export default memo(GroupUseRems);

--- a/src/components/FluidTypeScaleCalculator/Output/Output.tsx
+++ b/src/components/FluidTypeScaleCalculator/Output/Output.tsx
@@ -17,45 +17,54 @@ const Output = (props: Props) => {
   /** Helper to assemble a CSS custom property for a given font size step. */
   const getCustomPropertyName = (step: string) => `--${state.namingConvention}-${step}`;
 
-  const getFluidFontSizeVariables = (separator = '\n') =>
-    fontSizes
+  // We need the fluid variables in two scenarios, and in each scenario the indentation level is different
+  const getFluidFontSizeVariables = (indentLevel = 0) => {
+    const indentation = Array.from({ length: indentLevel }, () => '\t').join('');
+    return fontSizes
       .map(([step, { min, max, preferred }]) => {
-        return `${getCustomPropertyName(step)}: clamp(${min}, ${preferred}, ${max});`;
+        return `${indentation}${getCustomPropertyName(step)}: clamp(${min}, ${preferred}, ${max});`;
       })
-      .join(separator);
+      .join('\n')
+      .trim();
+  };
 
   let code: string | undefined;
 
   // Include fallbacks with feature queries for browsers that don't support clamp
   if (state.shouldIncludeFallbacks) {
+    const minFallbackVariables = fontSizes
+      .map(([step, { min }]) => {
+        return `\t\t${getCustomPropertyName(step)}: ${min};`;
+      })
+      .join('\n')
+      .trim();
+
+    const maxFallbackVariables = fontSizes
+      .map(([step, { max }]) => {
+        return `\t\t\t${getCustomPropertyName(step)}: ${max};`;
+      })
+      .join('\n')
+      .trim();
+
+    // Outdent to prevent the static code indentation from influencing the output string indentation
     code = outdent`
-      /* Fluid font size variables, for browsers that support clamp */
-      @supports (font-size: clamp(1rem, 1vw, 1rem)) {
+    /* Fluid font size variables, for browsers that support clamp */
+    @supports (font-size: clamp(1rem, 1vw, 1rem)) {
+      :root {
+        ${getFluidFontSizeVariables(2)}
+      }
+    }
+    /* Fallback variables for browsers that don't support clamp */
+    @supports not (font-size: clamp(1rem, 1vw, 1rem)) {
+      :root {
+        ${minFallbackVariables}
+      }
+      @media screen and (min-width: ${state.max.screenWidth}px) {
         :root {
-          ${getFluidFontSizeVariables('\n\t\t')}
+          ${maxFallbackVariables}
         }
       }
-      /* Fallback variables for browsers that don't support clamp */
-      @supports not (font-size: clamp(1rem, 1vw, 1rem)) {
-        :root {
-          ${fontSizes
-            .map(([step, { min }]) => {
-              return `\t${getCustomPropertyName(step)}: ${min};`;
-            })
-            // Extra tabs are needed for proper indentation
-            .join('\n\t\t')}
-        }
-        @media screen and (min-width: ${state.max.screenWidth}px) {
-          :root {
-            ${fontSizes
-              .map(([step, { max }]) => {
-                return `\t${getCustomPropertyName(step)}: ${max};`;
-              })
-              // Extra tabs are needed for proper indentation
-              .join('\n\t\t\t')}
-          }
-        }
-      }`;
+    }`;
   } else {
     code = getFluidFontSizeVariables();
   }

--- a/src/components/FluidTypeScaleCalculator/Preview/Preview.tsx
+++ b/src/components/FluidTypeScaleCalculator/Preview/Preview.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { DEFAULT_FONT_FAMILY } from '../../../constants';

--- a/src/components/GoogleFontsPicker/GoogleFontsPicker.tsx
+++ b/src/components/GoogleFontsPicker/GoogleFontsPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { QueryParamId } from '../../api/api.types';
 import { Delay } from '../../constants';
+import { QueryParamId } from '../../schema/schema.types';
 import { WithFonts } from '../../types';
 import Select, { SelectProps } from '../Select/Select';
 

--- a/src/pages/calculate.tsx
+++ b/src/pages/calculate.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = async (
 
   try {
     // Validate the query params first
-    validateQueryParams({ query, config: schema, fonts });
+    validateQueryParams({ query, fonts });
 
     // Then transform the query params to state
     const initialState: FormState = {

--- a/src/pages/calculate.tsx
+++ b/src/pages/calculate.tsx
@@ -1,9 +1,6 @@
 import { STATUS_CODES as REASON_PHRASES } from 'http';
 import { constants as HTTP_STATUS_CODES } from 'http2';
 import type { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
-import { QUERY_PARAM_CONFIG } from '../api/api.constants';
-import { QueryParamId, UserSuppliedQueryParams } from '../api/api.types';
-import { validateQueryParams } from '../api/api.validators';
 import ErrorPage from '../components/ErrorPage/ErrorPage';
 import FluidTypeScaleCalculator from '../components/FluidTypeScaleCalculator/FluidTypeScaleCalculator';
 import { initialFormState } from '../components/FluidTypeScaleCalculator/FluidTypeScaleCalculator.context';
@@ -12,8 +9,11 @@ import HeroBanner from '../components/HeroBanner/HeroBanner';
 import Info from '../components/Info/Info';
 import Layout from '../components/Layout/Layout';
 import site from '../data/site.json';
+import { schema } from '../schema/schema';
+import { QueryParamId, UserSuppliedQueryParams } from '../schema/schema.types';
+import { validateQueryParams } from '../schema/schema.validators';
 import { HTTPError, WithFonts } from '../types';
-import { getGoogleFontFamilies, throwIf } from '../utils';
+import { getGoogleFontFamilies } from '../utils';
 
 type CalculatePageProps = WithFonts & {
   /** The initial state with which to populate the app from query params. */
@@ -30,30 +30,30 @@ export const getServerSideProps = async (
 
   try {
     // Validate the query params first
-    validateQueryParams({ query, config: QUERY_PARAM_CONFIG, fonts });
+    validateQueryParams({ query, config: schema, fonts });
 
     // Then transform the query params to state
     const initialState: FormState = {
       min: {
-        fontSize: QUERY_PARAM_CONFIG[QueryParamId.minFontSize].getValue(query),
-        screenWidth: QUERY_PARAM_CONFIG[QueryParamId.minWidth].getValue(query),
-        ratio: QUERY_PARAM_CONFIG[QueryParamId.minRatio].getValue(query),
+        fontSize: schema[QueryParamId.minFontSize].parse(query),
+        screenWidth: schema[QueryParamId.minWidth].parse(query),
+        ratio: schema[QueryParamId.minRatio].parse(query),
       },
       max: {
-        fontSize: QUERY_PARAM_CONFIG[QueryParamId.maxFontSize].getValue(query),
-        screenWidth: QUERY_PARAM_CONFIG[QueryParamId.maxWidth].getValue(query),
-        ratio: QUERY_PARAM_CONFIG[QueryParamId.maxRatio].getValue(query),
+        fontSize: schema[QueryParamId.maxFontSize].parse(query),
+        screenWidth: schema[QueryParamId.maxWidth].parse(query),
+        ratio: schema[QueryParamId.maxRatio].parse(query),
       },
       typeScaleSteps: {
-        all: QUERY_PARAM_CONFIG[QueryParamId.allSteps].getValue(query),
-        base: QUERY_PARAM_CONFIG[QueryParamId.baseStep].getValue(query),
+        all: schema[QueryParamId.allSteps].parse(query),
+        base: schema[QueryParamId.baseStep].parse(query),
       },
-      namingConvention: QUERY_PARAM_CONFIG[QueryParamId.namingConvention].getValue(query),
-      shouldIncludeFallbacks: QUERY_PARAM_CONFIG[QueryParamId.shouldIncludeFallbacks].getValue(query),
-      shouldUseRems: QUERY_PARAM_CONFIG[QueryParamId.shouldUseRems].getValue(query),
-      remValueInPx: QUERY_PARAM_CONFIG[QueryParamId.remValueInPx].getValue(query),
-      roundingDecimalPlaces: QUERY_PARAM_CONFIG[QueryParamId.roundingDecimalPlaces].getValue(query),
-      fontFamily: QUERY_PARAM_CONFIG[QueryParamId.previewFont].getValue(query),
+      namingConvention: schema[QueryParamId.namingConvention].parse(query),
+      shouldIncludeFallbacks: schema[QueryParamId.shouldIncludeFallbacks].parse(query),
+      shouldUseRems: schema[QueryParamId.shouldUseRems].parse(query),
+      remValueInPx: schema[QueryParamId.remValueInPx].parse(query),
+      roundingDecimalPlaces: schema[QueryParamId.roundingDecimalPlaces].parse(query),
+      fontFamily: schema[QueryParamId.previewFont].parse(query),
     };
     return {
       props: {

--- a/src/schema/schema.parsers.test.ts
+++ b/src/schema/schema.parsers.test.ts
@@ -1,6 +1,6 @@
-import { parseCheckboxBoolean, parseNumber } from './api.transformers';
+import { parseCheckboxBoolean, parseNumber } from './schema.parsers';
 
-describe('API transformation functions', () => {
+describe('schema parser functions', () => {
   describe('parseNumber', () => {
     it('returns the fallback if the param is unspecified', () => {
       expect(parseNumber({ query: { foo: '42' }, id: 'unspecified', fallback: 0xfa11bac })).toStrictEqual(0xfa11bac);

--- a/src/schema/schema.parsers.ts
+++ b/src/schema/schema.parsers.ts
@@ -1,6 +1,6 @@
-import { QueryParamId, UserSuppliedQueryParams } from './api.types';
+import { UserSuppliedQueryParams } from './schema.types';
 
-export const getRawParam = (query: UserSuppliedQueryParams, id: string): string | undefined => query[id];
+export const parseRawValue = (query: UserSuppliedQueryParams, id: string): string | undefined => query[id];
 
 /** Parses the query parameter with the given ID as a number. Returns the default value if the param is not specified. */
 export const parseNumber = (options: {
@@ -11,9 +11,9 @@ export const parseNumber = (options: {
   /** A fallback value to return if the query param with the given ID is not found in the query string. */
   fallback: number;
 }): number => {
-  const param = getRawParam(options.query, options.id) ?? options.fallback;
-  if (typeof param === 'string' && !param) return NaN;
-  return Number(param);
+  const value = parseRawValue(options.query, options.id) ?? options.fallback;
+  if (typeof value === 'string' && !value) return NaN;
+  return Number(value);
 };
 
 /** Parses the query parameter with the given ID as a boolean value corresponding to a checkbox's checked state. */
@@ -23,18 +23,18 @@ export const parseCheckboxBoolean = (options: {
   /** The ID to look up in the query string. */
   id: string;
 }): boolean => {
-  const rawValue = getRawParam(options.query, options.id);
+  const value = parseRawValue(options.query, options.id);
 
   // HTML forms don't bother serializing checkboxes if they aren't checked. So fall back to false if the query param does not exist in the URL.
-  if (typeof rawValue === 'undefined') {
+  if (typeof value === 'undefined') {
     return false;
   }
 
   // If the query param exists but is an empty string (e.g., `?booleanWithNoValue`), return true
-  if (!rawValue) {
+  if (!value) {
     return true;
   }
 
   // Interpret the string as a boolean. Note that by default, HTML forms serialize checkboxes to `'on'` if they're checked. But our API also internally accepts `'true'` as a valid alias for `'on'` since it's a bit more intuitive.
-  return rawValue === 'on' || rawValue === 'true';
+  return value === 'on' || value === 'true';
 };

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,30 +1,24 @@
 import { DEFAULT_FONT_FAMILY } from '../constants';
 import typeScaleRatios from '../data/typeScaleRatios.json';
 import { isCommaSeparatedList, throwIf, toCommaSeparatedList } from '../utils';
-import { getRawParam, parseCheckboxBoolean, parseNumber } from './api.transformers';
-import { QueryParamConfig, QueryParamId } from './api.types';
-import {
-  isValidCheckedValue,
-  throwIfInvalidCheckboxBoolean,
-  throwIfNaN,
-  throwIfNotInteger,
-  throwIfOutOfBounds,
-} from './api.validators';
+import { parseCheckboxBoolean, parseNumber, parseRawValue } from './schema.parsers';
+import { QueryParamId, QueryParamSchema } from './schema.types';
+import { throwIfInvalidCheckboxBoolean, throwIfNaN, throwIfNotInteger, throwIfOutOfBounds } from './schema.validators';
 
-/** A config describing all of the valid query parameters recognized by the app on both the server side and client side (as input names).
+/** A schema describing all of the valid query parameters recognized by the app on both the server side and client side (as input names).
  * Each query param supplies functions for validating its own data, either on its own or in relation to other query params, as well as for
  * transforming the raw query param string to the desired value.
  */
-export const QUERY_PARAM_CONFIG: QueryParamConfig = {
+export const schema: QueryParamSchema = {
   [QueryParamId.minFontSize]: {
     id: QueryParamId.minFontSize,
     default: 16,
     min: 0,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const minFontSize = this.getValue(query);
+      const minFontSize = this.parse(query);
       throwIfNaN(this.id, minFontSize);
       throwIfOutOfBounds(this.id, minFontSize, { min: this.min, max: this.max });
     },
@@ -33,15 +27,15 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     id: QueryParamId.minWidth,
     default: 400,
     min: 0,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     // This is a good example of why the validator functions accept the raw query string and a reference to the entire config:
     // Sometimes, validating one query param requires checking another query param. If the validator were to only accept the current value
     // for this particular query param, that would not be possible.
     validate({ config, query }) {
-      const minScreenWidth = this.getValue(query);
-      const maxScreenWidth = config[QueryParamId.maxWidth].getValue(query);
+      const minScreenWidth = this.parse(query);
+      const maxScreenWidth = config[QueryParamId.maxWidth].parse(query);
       throwIfNaN(this.id, minScreenWidth);
       throwIfOutOfBounds(this.id, minScreenWidth, { min: this.min, max: maxScreenWidth - 1 });
     },
@@ -50,11 +44,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     id: QueryParamId.minRatio,
     default: typeScaleRatios.majorThird.ratio,
     min: 0,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const minRatio = this.getValue(query);
+      const minRatio = this.parse(query);
       throwIfNaN(this.id, minRatio);
       throwIfOutOfBounds(this.id, minRatio, { min: this.min, max: this.max });
     },
@@ -63,11 +57,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     id: QueryParamId.maxFontSize,
     default: 19,
     min: 0,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const maxFontSize = this.getValue(query);
+      const maxFontSize = this.parse(query);
       throwIfNaN(this.id, maxFontSize);
       throwIfOutOfBounds(this.id, maxFontSize, { min: this.min, max: this.max });
     },
@@ -75,12 +69,12 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
   [QueryParamId.maxWidth]: {
     id: QueryParamId.maxWidth,
     default: 1280,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query, config }) {
-      const minScreenWidth = config[QueryParamId.minWidth].getValue(query);
-      const maxScreenWidth = this.getValue(query);
+      const minScreenWidth = config[QueryParamId.minWidth].parse(query);
+      const maxScreenWidth = this.parse(query);
       throwIfNaN(this.id, maxScreenWidth);
       throwIfOutOfBounds(this.id, maxScreenWidth, { min: minScreenWidth + 1, max: this.max });
     },
@@ -89,11 +83,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     id: QueryParamId.maxRatio,
     default: typeScaleRatios.perfectFourth.ratio,
     min: 0,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const maxRatio = this.getValue(query);
+      const maxRatio = this.parse(query);
       throwIfNaN(this.id, maxRatio);
       throwIfOutOfBounds(this.id, maxRatio, { min: this.min, max: this.max });
     },
@@ -101,14 +95,14 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
   [QueryParamId.allSteps]: {
     id: QueryParamId.allSteps,
     default: ['sm', 'base', 'md', 'lg', 'xl', 'xxl', 'xxxl'],
-    getValue(query) {
-      const rawString = getRawParam(query, this.id);
+    parse(query) {
+      const rawString = parseRawValue(query, this.id);
       if (!rawString) return this.default;
       return toCommaSeparatedList(rawString);
     },
     validate({ query, config }) {
-      const allSteps = this.getValue(query);
-      const baseStep = config[QueryParamId.baseStep].getValue(query);
+      const allSteps = this.parse(query);
+      const baseStep = config[QueryParamId.baseStep].parse(query);
       throwIf(!allSteps.includes(baseStep), `${this.id} (${allSteps}) does not include the base step (${baseStep}).`);
       // While this may seem like it will never throw, imagine a scenario where a user enters x,y;z. Splitting it yields ['x', 'y;z'].
       // And our regex strictly requires that each item in the list only use alphanumeric characters.
@@ -118,12 +112,12 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
   [QueryParamId.baseStep]: {
     id: QueryParamId.baseStep,
     default: 'base',
-    getValue(query) {
-      return getRawParam(query, this.id) ?? this.default;
+    parse(query) {
+      return parseRawValue(query, this.id) ?? this.default;
     },
     validate({ config, query }) {
-      const baseStep = this.getValue(query);
-      const allSteps = config[QueryParamId.allSteps].getValue(query);
+      const baseStep = this.parse(query);
+      const allSteps = config[QueryParamId.allSteps].parse(query);
       throwIf(
         !allSteps.includes(baseStep),
         `The base step ${baseStep} was not found in the list of all steps (${allSteps}).`
@@ -133,32 +127,32 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
   [QueryParamId.namingConvention]: {
     id: QueryParamId.namingConvention,
     default: 'font-size',
-    getValue(query) {
-      return getRawParam(query, this.id) ?? this.default;
+    parse(query) {
+      return parseRawValue(query, this.id) ?? this.default;
     },
     validate({ query }) {
-      throwIf(!this.getValue(query), `${this.id} must be a non-empty string`);
+      throwIf(!this.parse(query), `${this.id} must be a non-empty string`);
     },
   },
   [QueryParamId.shouldIncludeFallbacks]: {
     id: QueryParamId.shouldIncludeFallbacks,
     default: false,
-    getValue(query) {
+    parse(query) {
       return parseCheckboxBoolean({ query, id: this.id });
     },
     validate({ query }) {
-      const rawValue = getRawParam(query, this.id);
+      const rawValue = parseRawValue(query, this.id);
       throwIfInvalidCheckboxBoolean(this.id, rawValue);
     },
   },
   [QueryParamId.shouldUseRems]: {
     id: QueryParamId.shouldUseRems,
     default: true,
-    getValue(query) {
+    parse(query) {
       return parseCheckboxBoolean({ query, id: this.id });
     },
     validate({ query }) {
-      const rawValue = getRawParam(query, this.id);
+      const rawValue = parseRawValue(query, this.id);
       throwIfInvalidCheckboxBoolean(this.id, rawValue);
     },
   },
@@ -166,11 +160,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     id: QueryParamId.remValueInPx,
     default: 16,
     min: 1,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const remValueInPx = this.getValue(query);
+      const remValueInPx = this.parse(query);
       throwIfNaN(this.id, remValueInPx);
       throwIfNotInteger(this.id, remValueInPx);
       throwIfOutOfBounds(this.id, remValueInPx, { min: this.min });
@@ -181,11 +175,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
     default: 2,
     min: 0,
     max: 10,
-    getValue(query) {
+    parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
     validate({ query }) {
-      const decimalPlaces = this.getValue(query);
+      const decimalPlaces = this.parse(query);
       throwIfNaN(this.id, decimalPlaces);
       throwIfNotInteger(this.id, decimalPlaces);
       throwIfOutOfBounds(this.id, decimalPlaces, { min: this.min, max: this.max });
@@ -194,11 +188,11 @@ export const QUERY_PARAM_CONFIG: QueryParamConfig = {
   [QueryParamId.previewFont]: {
     id: QueryParamId.previewFont,
     default: DEFAULT_FONT_FAMILY,
-    getValue(query) {
-      return getRawParam(query, this.id) ?? this.default;
+    parse(query) {
+      return parseRawValue(query, this.id) ?? this.default;
     },
     validate({ query, fonts }) {
-      const font = this.getValue(query);
+      const font = this.parse(query);
       const isUnrecognizedFont = !fonts.includes(font);
       throwIf(isUnrecognizedFont, `${font} is not a recognized Google Font.`);
     },

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -30,12 +30,9 @@ export const schema: QueryParamSchema = {
     parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
-    // This is a good example of why the validator functions accept the raw query string and a reference to the entire config:
-    // Sometimes, validating one query param requires checking another query param. If the validator were to only accept the current value
-    // for this particular query param, that would not be possible.
-    validate({ config, query }) {
+    validate({ query }) {
       const minScreenWidth = this.parse(query);
-      const maxScreenWidth = config[QueryParamId.maxWidth].parse(query);
+      const maxScreenWidth = schema[QueryParamId.maxWidth].parse(query);
       throwIfNaN(this.id, minScreenWidth);
       throwIfOutOfBounds(this.id, minScreenWidth, { min: this.min, max: maxScreenWidth - 1 });
     },
@@ -72,8 +69,8 @@ export const schema: QueryParamSchema = {
     parse(query) {
       return parseNumber({ query, id: this.id, fallback: this.default });
     },
-    validate({ query, config }) {
-      const minScreenWidth = config[QueryParamId.minWidth].parse(query);
+    validate({ query }) {
+      const minScreenWidth = schema[QueryParamId.minWidth].parse(query);
       const maxScreenWidth = this.parse(query);
       throwIfNaN(this.id, maxScreenWidth);
       throwIfOutOfBounds(this.id, maxScreenWidth, { min: minScreenWidth + 1, max: this.max });
@@ -100,9 +97,9 @@ export const schema: QueryParamSchema = {
       if (!rawString) return this.default;
       return toCommaSeparatedList(rawString);
     },
-    validate({ query, config }) {
+    validate({ query }) {
       const allSteps = this.parse(query);
-      const baseStep = config[QueryParamId.baseStep].parse(query);
+      const baseStep = schema[QueryParamId.baseStep].parse(query);
       throwIf(!allSteps.includes(baseStep), `${this.id} (${allSteps}) does not include the base step (${baseStep}).`);
       // While this may seem like it will never throw, imagine a scenario where a user enters x,y;z. Splitting it yields ['x', 'y;z'].
       // And our regex strictly requires that each item in the list only use alphanumeric characters.
@@ -115,9 +112,9 @@ export const schema: QueryParamSchema = {
     parse(query) {
       return parseRawValue(query, this.id) ?? this.default;
     },
-    validate({ config, query }) {
+    validate({ query }) {
       const baseStep = this.parse(query);
-      const allSteps = config[QueryParamId.allSteps].parse(query);
+      const allSteps = schema[QueryParamId.allSteps].parse(query);
       throwIf(
         !allSteps.includes(baseStep),
         `The base step ${baseStep} was not found in the list of all steps (${allSteps}).`
@@ -192,9 +189,9 @@ export const schema: QueryParamSchema = {
       return parseRawValue(query, this.id) ?? this.default;
     },
     validate({ query, fonts }) {
-      const font = this.parse(query);
-      const isUnrecognizedFont = !fonts.includes(font);
-      throwIf(isUnrecognizedFont, `${font} is not a recognized Google Font.`);
+      const fontFamily = this.parse(query);
+      const isUnrecognizedFont = !fonts.includes(fontFamily);
+      throwIf(isUnrecognizedFont, `${fontFamily} is not a recognized Google Font.`);
     },
   },
 };

--- a/src/schema/schema.types.ts
+++ b/src/schema/schema.types.ts
@@ -26,11 +26,9 @@ export enum QueryParamId {
 /** A record of arbitrary query params supplied by users. */
 export type UserSuppliedQueryParams = Record<string, string>;
 
-export type QueryParamValidatorOptions = WithFonts & {
+export type QueryValidatorOptions = WithFonts & {
   /** The query params passed in by the user. */
   query: UserSuppliedQueryParams;
-  /** A reference to the query param config itself. */
-  config: QueryParamSchema;
 };
 
 /** A query parameter with a method to fetch its value and a corresponding validator method that checks the value. */
@@ -40,7 +38,7 @@ export type ValidatedQueryParam<T> = {
   /** Parses and returns the value from the query string. */
   parse: (query: UserSuppliedQueryParams) => T;
   /** Validator method to check the query param. Throws an error if the value is invalid. */
-  validate: (options: QueryParamValidatorOptions) => void;
+  validate: (query: QueryValidatorOptions) => void;
 };
 
 export type NumericQueryParam = ValidatedQueryParam<number> & {
@@ -104,6 +102,7 @@ export type ParamFallback = ValidatedQueryParam<boolean> & {
 
 export type ParamFontFamily = ValidatedQueryParam<string> & {
   id: QueryParamId.previewFont;
+  validate: (options: QueryValidatorOptions) => void;
 };
 
 export type QueryParam =

--- a/src/schema/schema.types.ts
+++ b/src/schema/schema.types.ts
@@ -30,7 +30,7 @@ export type QueryParamValidatorOptions = WithFonts & {
   /** The query params passed in by the user. */
   query: UserSuppliedQueryParams;
   /** A reference to the query param config itself. */
-  config: QueryParamConfig;
+  config: QueryParamSchema;
 };
 
 /** A query parameter with a method to fetch its value and a corresponding validator method that checks the value. */
@@ -38,7 +38,7 @@ export type ValidatedQueryParam<T> = {
   /** The default value for this query parameter. */
   default: T;
   /** Parses and returns the value from the query string. */
-  getValue: (query: UserSuppliedQueryParams) => T;
+  parse: (query: UserSuppliedQueryParams) => T;
   /** Validator method to check the query param. Throws an error if the value is invalid. */
   validate: (options: QueryParamValidatorOptions) => void;
 };
@@ -123,4 +123,4 @@ export type QueryParam =
   | ParamFontFamily;
 
 /** Mapped type where they keys `K` correspond to shapes that extend `{ id: K }`. Defines a config for each query parameter. */
-export type QueryParamConfig = MapDiscriminatedUnion<QueryParam, 'id'>;
+export type QueryParamSchema = MapDiscriminatedUnion<QueryParam, 'id'>;

--- a/src/schema/schema.validators.test.ts
+++ b/src/schema/schema.validators.test.ts
@@ -1,4 +1,4 @@
-import { throwIfNaN, throwIfNotInteger, throwIfOutOfBounds } from './api.validators';
+import { throwIfNaN, throwIfNotInteger, throwIfOutOfBounds } from './schema.validators';
 
 describe('API validator functions', () => {
   describe('throwIfNaN', () => {

--- a/src/schema/schema.validators.ts
+++ b/src/schema/schema.validators.ts
@@ -1,6 +1,5 @@
-import { COMMA_SEPARATED_LIST_REGEX } from '../constants';
 import { isNumber, throwIf } from '../utils';
-import { QueryParamId, QueryParamValidatorOptions } from './api.types';
+import { QueryParamId, QueryParamValidatorOptions } from './schema.types';
 
 /** Returns `true` if the given value represents a valid checkbox state. */
 export const isValidCheckedValue = (value: string) => {

--- a/src/schema/schema.validators.ts
+++ b/src/schema/schema.validators.ts
@@ -1,5 +1,6 @@
 import { isNumber, throwIf } from '../utils';
-import { QueryParamId, QueryParamValidatorOptions } from './schema.types';
+import { schema } from './schema';
+import { QueryParamId, QueryValidatorOptions } from './schema.types';
 
 /** Returns `true` if the given value represents a valid checkbox state. */
 export const isValidCheckedValue = (value: string) => {
@@ -33,11 +34,11 @@ export const throwIfInvalidCheckboxBoolean = (id: string, rawValue?: string) => 
 /** Validates user-supplied query params based on a config of valid query params and other data supplied to the app (e.g., font family names).
  * Throws an error if any of the user-supplied query params are unrecognized or invalid.
  */
-export const validateQueryParams = (options: QueryParamValidatorOptions) => {
+export const validateQueryParams = (options: QueryValidatorOptions) => {
   Object.keys(options.query).forEach((id) => {
-    const isRecognizedParam = id in options.config;
+    const isRecognizedParam = id in schema;
     throwIf(!isRecognizedParam, `${id} is not a recognized query parameter.`);
-    const queryParam = options.config[id as QueryParamId];
+    const queryParam = schema[id as QueryParamId];
     queryParam.validate(options);
   });
 };


### PR DESCRIPTION
- Instead of consuming the state context internally within each form input group, we now pass down only the data the components need and memoize them to prevent unnecessary re-renders. React dev tools were highlighting lots of re-renders for some of the inputs.
- Debounces URL updates to fix a console warning.
- Cleans up code output logic for indentation.
- Renames `api/*` => `schema/*` to match terminology used by libraries like zod and yup. Also renames `getValue` => `parse`, etc.